### PR TITLE
Remove SetMinFps and SetMaxFps with SetFps.  Remove ApplyFrameLimit() greatly simplifying code.

### DIFF
--- a/Source/Urho3D/Engine/Application.cpp
+++ b/Source/Urho3D/Engine/Application.cpp
@@ -115,8 +115,21 @@ int Application::Run()
 
         // Platforms other than iOS/tvOS and Emscripten run a blocking main loop
 #if !defined(IOS) && !defined(TVOS) && !defined(__EMSCRIPTEN__)
-        while (!engine_->IsExiting())
+
+
+        while (!engine_->IsExiting()) {
+            //free spin until the timer is near the target timestep. sleep as much as possible while maintaining the target time.
+            //sleep until the last fraction of the timestep.
+            float fps = engine_->GetFps();
+            float timeStep = 1.0f / fps;
+            float lastFractionTime = timeStep / 10.0f;
+            while (engine_->GetTimeToNextFrame() > 0.0f)
+            {
+                if(engine_->GetTimeToNextFrame() > lastFractionTime)
+                    Time::Sleep((engine_->GetTimeToNextFrame() - lastFractionTime)/1000.0f);
+            }
             engine_->RunFrame();
+        }
 
         Stop();
         // iOS/tvOS will setup a timer for running animation frames so eg. Game Center can run. In this case we do not

--- a/Source/Urho3D/Engine/Engine.cpp
+++ b/Source/Urho3D/Engine/Engine.cpp
@@ -466,6 +466,9 @@ void Engine::RunFrame()
     URHO3D_PROFILE("RunFrame");
 
     float timeStepActual = frameTimer_.GetUSec(false)/1000000.0f;
+    //clamp the actual timestep to +- 10% of the target.  in case of extra long frame times.
+    timeStepActual = Clamp(timeStepActual, timeStepTarget_ - timeStepTarget_ * 0.1f, timeStepTarget_ + timeStepTarget_ * 0.1f);
+
     frameTimer_.Reset();
 
     {

--- a/Source/Urho3D/Engine/Engine.h
+++ b/Source/Urho3D/Engine/Engine.h
@@ -59,14 +59,8 @@ public:
     Console* CreateConsole();
     /// Create the debug hud.
     DebugHud* CreateDebugHud();
-    /// Set minimum frames per second. If FPS goes lower than this, time will appear to slow down.
-    void SetMinFps(int fps);
-    /// Set maximum frames per second. The engine will sleep if FPS is higher than this.
-    void SetMaxFps(int fps);
-    /// Set maximum frames per second when the application does not have input focus.
-    void SetMaxInactiveFps(int fps);
-    /// Set how many frames to average for timestep smoothing. Default is 2. 1 disables smoothing.
-    void SetTimeStepSmoothing(int frames);
+    /// Set the target frames per second.
+    void SetFps(int fps);
     /// Set whether to pause update events and audio when minimized.
     void SetPauseMinimized(bool enable);
     /// Set whether to exit automatically on exit request (window close button.)
@@ -83,20 +77,12 @@ public:
     void DumpMemory();
 
     /// Get timestep of the next frame. Updated by ApplyFrameLimit().
-    float GetNextTimeStep() const { return timeStep_; }
+    float GetNextTimeStep() const { return timeStepTarget_; }
 
-    /// Return the minimum frames per second.
-    int GetMinFps() const { return minFps_; }
+    int GetFps() const { return Round(1.0f / timeStepTarget_); }
 
-    /// Return the maximum frames per second.
-    int GetMaxFps() const { return maxFps_; }
-
-    /// Return the maximum frames per second when the application does not have input focus.
-    int GetMaxInactiveFps() const { return maxInactiveFps_; }
-
-    /// Return how many frames to average for timestep smoothing.
-    int GetTimeStepSmoothing() const { return timeStepSmoothing_; }
-
+    /// Get the time remaining until the next frame should be rendered in seconds.
+    float GetTimeToNextFrame() { return timeStepTarget_ - frameTimer_.GetUSec(false)/1000000.0f; }
     /// Return whether to pause update events and audio when minimized.
     bool GetPauseMinimized() const { return pauseMinimized_; }
 
@@ -113,11 +99,10 @@ public:
     bool IsHeadless() const { return headless_; }
 
     /// Send frame update events.
-    void Update();
+    void Update(float timeStep);
     /// Render after frame update.
-    void Render();
-    /// Get the timestep for the next frame and sleep for frame limiting if necessary.
-    void ApplyFrameLimit();
+    void Render(float timeStep);
+
 
     /// Parse the engine startup parameters map from command line arguments.
     static void DefineParameters(CLI::App& commandLine, VariantMap& engineParameters);
@@ -135,18 +120,9 @@ private:
 
     /// Frame update timer.
     HiresTimer frameTimer_;
-    /// Previous timesteps for smoothing.
-    ea::vector<float> lastTimeSteps_;
-    /// Next frame timestep in seconds.
-    float timeStep_;
-    /// How many frames to average for the smoothed timestep.
-    unsigned timeStepSmoothing_;
-    /// Minimum frames per second.
-    unsigned minFps_;
-    /// Maximum frames per second.
-    unsigned maxFps_;
-    /// Maximum frames per second when the application does not have input focus.
-    unsigned maxInactiveFps_;
+    /// timestep target
+    float timeStepTarget_;
+
     /// Pause when minimized flag.
     bool pauseMinimized_;
 #ifdef URHO3D_TESTING


### PR DESCRIPTION
Removes SetMinFps and SetMaxFps in favor of a fixed target timing model. ( SetFps ). Removes ApplyFrameLimit() and instead the application simply calls RunFrame() when the target time is reached, sleeping in extra time otherwise.