### PR TITLE
Tracy-Profiler CMake Fixes

### DIFF
--- a/Source/ThirdParty/CMakeLists.txt
+++ b/Source/ThirdParty/CMakeLists.txt
@@ -84,7 +84,7 @@ if (NOT MINI_URHO)
         endif ()
     endif ()
 
-    if (URHO3D_PROFILING AND URHO3D_NETWORK)
+    if (URHO3D_PROFILING)
         if (NOT TARGET GLEW AND URHO3D_TOOLS)
             add_subdirectory (GLEW)
         endif ()

--- a/Source/ThirdParty/CMakeLists.txt
+++ b/Source/ThirdParty/CMakeLists.txt
@@ -84,7 +84,7 @@ if (NOT MINI_URHO)
         endif ()
     endif ()
 
-    if (URHO3D_PROFILING)
+    if (URHO3D_PROFILING AND URHO3D_NETWORK)
         if (NOT TARGET GLEW AND URHO3D_TOOLS)
             add_subdirectory (GLEW)
         endif ()

--- a/Source/ThirdParty/tracy/CMakeLists.txt
+++ b/Source/ThirdParty/tracy/CMakeLists.txt
@@ -60,7 +60,11 @@ if (URHO3D_TOOLS AND URHO3D_SYSTEMUI)
     endmacro ()
 
     file (GLOB_RECURSE TRACY_PROFILER_SOURCE_FILES profiler/src/*.cpp)
-    add_executable (tracy-profiler WIN32 ${SERVER_SOURCE_FILES} ${COMMON_SOURCE_FILES} ${TRACY_PROFILER_SOURCE_FILES})
+    
+    if (NOT URHO3D_WIN32_CONSOLE)
+        set (TARGET_TYPE WIN32)
+    endif ()
+    add_executable (tracy-profiler ${TARGET_TYPE} ${SERVER_SOURCE_FILES} ${COMMON_SOURCE_FILES} ${TRACY_PROFILER_SOURCE_FILES})
     target_compile_definitions(tracy-profiler PUBLIC -DTRACY_ROOT_WINDOW=1)
     set_target_properties(tracy-profiler PROPERTIES OUTPUT_NAME Profiler)
     setup_tracy_profiler_target(tracy-profiler)


### PR DESCRIPTION
Only Add Tracy if URHO3D_NETWORK is enabled.  
Add target type logic to tracy-profiler add_executable(...)