### PR TITLE
Scene/IO/Resource: Implement URHO3D_OBJECT_ATTRIBUTE() macro

### DIFF
--- a/Docs/Reference.dox
+++ b/Docs/Reference.dox
@@ -2553,6 +2553,7 @@ The folowing macros can be used to define an attribute:
 - `URHO3D_ENUM_ATTRIBUTE_EX`: The same as `URHO3D_ATTRIBUTE_EX`, used for enumerations.
 - `URHO3D_ENUM_ACCESSOR_ATTRIBUTE`: The same as `URHO3D_ACCESSOR_ATTRIBUTE`, used for enumerations.
 - `URHO3D_CUSTOM_ENUM_ATTRIBUTE`: The same as `URHO3D_CUSTOM_ATTRIBUTE`, used for enumerations.
+- `URHO3D_OBJECT_ATTRIBUTE`: Member of the object which is another object. Must be SharedPtr<> of \ref Serializable or it's subclasses.
 
 To implement side effects to attributes, the default attribute access functions in Serializable can be overridden. See \ref Serializable::OnSetAttribute "OnSetAttribute()" and \ref Serializable::OnGetAttribute "OnGetAttribute()".
 

--- a/Source/Urho3D/Core/Context.cpp
+++ b/Source/Urho3D/Core/Context.cpp
@@ -241,11 +241,17 @@ void Context::RemoveSubsystem(StringHash objectType)
 AttributeHandle Context::RegisterAttribute(StringHash objectType, const AttributeInfo& attr)
 {
     // None or pointer types can not be supported
-    if (attr.type_ == VAR_NONE || attr.type_ == VAR_VOIDPTR || attr.type_ == VAR_PTR
-        || attr.type_ == VAR_CUSTOM_HEAP || attr.type_ == VAR_CUSTOM_STACK)
+    if (attr.type_ == VAR_NONE || attr.type_ == VAR_VOIDPTR || attr.type_ == VAR_PTR)
     {
-        URHO3D_LOGWARNING("Attempt to register unsupported attribute type " + Variant::GetTypeName(attr.type_) + " to class " +
+        URHO3D_LOGWARNING("Attempt to register unsupported attribute type {} to class {}", Variant::GetTypeName(attr.type_),
             GetTypeName(objectType));
+        return AttributeHandle();
+    }
+
+    // Only SharedPtr<> of Serializable or it's subclasses are supported in attributes
+    if (attr.defaultValue_.IsCustom() && !attr.defaultValue_.IsCustomType<SharedPtr<Serializable>>())
+    {
+        URHO3D_LOGWARNING("Attempt to register unsupported attribute of custom type to class {}", GetTypeName(objectType));
         return AttributeHandle();
     }
 

--- a/Source/Urho3D/Core/Variant.h
+++ b/Source/Urho3D/Core/Variant.h
@@ -319,6 +319,7 @@ union VariantValue
 };
 
 // TODO: static_assert(sizeof(VariantValue) == VARIANT_VALUE_SIZE, "Unexpected size of VariantValue");
+static_assert(sizeof(CustomVariantValueImpl<SharedPtr<RefCounted>>) <= VARIANT_VALUE_SIZE, "SharedPtr<> does not fit into variant.");
 
 /// Variable that supports a fixed set of types.
 class URHO3D_API Variant

--- a/Source/Urho3D/IO/Deserializer.h
+++ b/Source/Urho3D/IO/Deserializer.h
@@ -29,6 +29,8 @@
 namespace Urho3D
 {
 
+class Context;
+
 /// Abstract stream for reading.
 class URHO3D_API Deserializer
 {
@@ -127,8 +129,8 @@ public:
     ResourceRefList ReadResourceRefList();
     /// Read a variant.
     Variant ReadVariant();
-    /// Read a variant whose type is already known.
-    Variant ReadVariant(VariantType type);
+    /// Read a variant whose type is already known. Context is required for SharedPtr<Serializable>.
+    Variant ReadVariant(VariantType type, Context* context = nullptr);
     /// Read a variant vector.
     VariantVector ReadVariantVector();
     /// Read a string vector.

--- a/Source/Urho3D/Resource/JSONValue.h
+++ b/Source/Urho3D/Resource/JSONValue.h
@@ -256,8 +256,8 @@ public:
     Variant GetVariant() const;
     /// Set variant value, context must provide for resource ref.
     void SetVariantValue(const Variant& variant, Context* context = nullptr);
-    /// Return a variant with type.
-    Variant GetVariantValue(VariantType type) const;
+    /// Return a variant with type, context must be provided for serializables.
+    Variant GetVariantValue(VariantType type, Context* context = nullptr) const;
     /// Set variant map, context must provide for resource ref.
     void SetVariantMap(const VariantMap& variantMap, Context* context = nullptr);
     /// Return a variant map.

--- a/Source/Urho3D/Resource/XMLElement.h
+++ b/Source/Urho3D/Resource/XMLElement.h
@@ -41,6 +41,7 @@ class xpath_variable_set;
 namespace Urho3D
 {
 
+class Context;
 class XMLFile;
 class XPathQuery;
 class XPathResultSet;
@@ -253,8 +254,8 @@ public:
     Quaternion GetQuaternion(const ea::string& name) const;
     /// Return a variant attribute, or empty if missing.
     Variant GetVariant() const;
-    /// Return a variant attribute with static type.
-    Variant GetVariantValue(VariantType type) const;
+    /// Return a variant attribute with static type. Context must be provided for loading SharedPtr<Serializable>.
+    Variant GetVariantValue(VariantType type, Context* context=nullptr) const;
     /// Return a resource reference attribute, or empty if missing.
     ResourceRef GetResourceRef() const;
     /// Return a resource reference list attribute, or empty if missing.

--- a/Source/Urho3D/Scene/Serializable.cpp
+++ b/Source/Urho3D/Scene/Serializable.cpp
@@ -312,7 +312,7 @@ bool Serializable::Load(Deserializer& source)
             return false;
         }
 
-        Variant varValue = source.ReadVariant(attr.type_);
+        Variant varValue = source.ReadVariant(attr.type_, context_);
         OnSetAttribute(attr, varValue);
     }
 
@@ -396,7 +396,7 @@ bool Serializable::LoadXML(const XMLElement& source)
                         URHO3D_LOGWARNING("Unknown enum value " + value + " in attribute " + attr.name_);
                 }
                 else
-                    varValue = attrElem.GetVariantValue(attr.type_);
+                    varValue = attrElem.GetVariantValue(attr.type_, context_);
 
                 if (!varValue.IsEmpty())
                     OnSetAttribute(attr, varValue);
@@ -484,7 +484,7 @@ bool Serializable::LoadJSON(const JSONValue& source)
                         URHO3D_LOGWARNING("Unknown enum value " + valueStr + " in attribute " + attr.name_);
                 }
                 else
-                    varValue = value.GetVariantValue(attr.type_);
+                    varValue = value.GetVariantValue(attr.type_, context_);
 
                 if (!varValue.IsEmpty())
                     OnSetAttribute(attr, varValue);

--- a/Source/Urho3D/Scene/Serializable.h
+++ b/Source/Urho3D/Scene/Serializable.h
@@ -225,6 +225,11 @@ SharedPtr<AttributeAccessor> MakeVariantAttributeAccessor(TGetFunction getFuncti
     [](const ClassName& self, Urho3D::Variant& value) { value = static_cast<int>(self.getFunction()); }, \
     [](ClassName& self, const Urho3D::Variant& value) { self.setFunction(static_cast<typeName>(value.Get<int>())); })
 
+/// Make get/set object attribute accessor.
+#define URHO3D_MAKE_MEMBER_OBJECT_ATTRIBUTE_ACCESSOR(variable) Urho3D::MakeVariantAttributeAccessor<ClassName>( \
+    [](const ClassName& self, Urho3D::Variant& value) { value.SetCustom(SharedPtr<Serializable>(static_cast<Serializable*>(self.variable.Get()))); }, \
+    [](ClassName& self, const Urho3D::Variant& value) { self.variable.StaticCast(value.GetCustom<SharedPtr<Serializable>>()); })
+
 /// Attribute metadata.
 namespace AttributeMetadata
 {
@@ -268,6 +273,10 @@ namespace AttributeMetadata
 /// Define an enum attribute with custom setter and getter. Zero-based enum values are mapped to names through an array of C string pointers.
 #define URHO3D_CUSTOM_ENUM_ATTRIBUTE(name, getFunction, setFunction, enumNames, defaultValue, mode) context->RegisterAttribute<ClassName>(Urho3D::AttributeInfo( \
     Urho3D::VAR_INT, name, Urho3D::MakeVariantAttributeAccessor<ClassName>(getFunction, setFunction), enumNames, static_cast<int>(defaultValue), mode))
+/// Define an object attribute. Object must be SharedPtr<> of Serializable or it's subclass.
+#define URHO3D_OBJECT_ATTRIBUTE(name, variable, mode) context->RegisterAttribute<ClassName>(Urho3D::AttributeInfo( \
+    sizeof(CustomVariantValueImpl<SharedPtr<Serializable>>) <= VARIANT_VALUE_SIZE ? VAR_CUSTOM_STACK : VAR_CUSTOM_HEAP, name, \
+    URHO3D_MAKE_MEMBER_OBJECT_ATTRIBUTE_ACCESSOR(variable), nullptr, Urho3D::MakeCustomValue(SharedPtr<Serializable>()), mode))
 
 /// Deprecated. Use URHO3D_ACCESSOR_ATTRIBUTE instead.
 #define URHO3D_MIXED_ACCESSOR_ATTRIBUTE(name, getFunction, setFunction, typeName, defaultValue, mode) URHO3D_ACCESSOR_ATTRIBUTE(name, getFunction, setFunction, typeName, defaultValue, mode)


### PR DESCRIPTION
...for `SharedPtr<Serializable>` object registration as attributes and their serialization in xml/json/binary. At this point multiple references to single object instance would be serialized multiple times and result in multiple new objects when deserialized.

Test sample:
```cpp
class Test : public Serializable
{
    URHO3D_OBJECT(Test, Serializable);
public:
    Test(Context* context) : Serializable(context)
    {
    }

    static void RegisterObject(Context* context)
    {
        URHO3D_COPY_BASE_ATTRIBUTES(Serializable);
        URHO3D_OBJECT_ATTRIBUTE("My Node Attribute", node_, AM_DEFAULT);
    }

    SharedPtr<Node> node_;
};
```
```cpp
    Test test(context_);
    test.node_ = context_->CreateObject<Node>();
    test.node_->SetName("foobar");

    JSONFile json(context_);
    test.SaveJSON(json.GetRoot());
    json.SaveFile("/tmp/serializable.json");

    Test loaded(context_);
    loaded.LoadJSON(json.GetRoot());

    XMLFile xml(context_);
    XMLElement root = xml.GetOrCreateRoot("serializable");
    test.SaveXML(root);
    xml.SaveFile("/tmp/serializable.xml");

    Test loaded2(context_);
    loaded2.LoadXML(root);

    {
        File bin(context_);
        bin.Open("/tmp/serializable.bin", FILE_WRITE);
        test.Save(bin);
    }

    File bin(context_);
    bin.Open("/tmp/serializable.bin", FILE_READ);
    Test loaded3(context_);
    loaded3.Load(bin);
```

@eugeneko i would like your blessing for this one.