### PR TITLE
Change mouse wheel handling.

### DIFF
--- a/Source/Urho3D/IO/Archive.h
+++ b/Source/Urho3D/IO/Archive.h
@@ -158,18 +158,18 @@ public:
     /// - There is no corresponding BeginBlock call.
     virtual bool EndBlock() = 0;
 
-    /// @name Serialize keys
-    /// @{
+    /// \name Serialize keys
+    /// \{
 
     /// Serialize string key of the Map block.
     virtual bool SerializeKey(ea::string& key) = 0;
     /// Serialize unsigned integer key of the Map block.
     virtual bool SerializeKey(unsigned& key) = 0;
 
-    /// @}
+    /// \}
 
-    /// @name Serialize elements
-    /// @{
+    /// \name Serialize elements
+    /// \{
 
     /// Serialize bool.
     virtual bool Serialize(const char* name, bool& value) = 0;
@@ -201,7 +201,7 @@ public:
     /// Serialize Variable Length Encoded unsigned integer, up to 29 significant bits.
     virtual bool SerializeVLE(const char* name, unsigned& value) = 0;
 
-    /// @}
+    /// \}
 
     /// Validate element or block name.
     static bool ValidateName(ea::string_view name);
@@ -215,7 +215,7 @@ public:
     }
 
     /// Open block helpers
-    /// @{
+    /// \{
 
     /// Open Sequential block. Will be automatically closed when returned object is destroyed.
     ArchiveBlock OpenSequentialBlock(const char* name) { return OpenBlock(name, 0, false, ArchiveBlockType::Sequential); }
@@ -231,7 +231,7 @@ public:
     /// Open safe Unordered block. Will be automatically closed when returned object is destroyed.
     ArchiveBlock OpenSafeUnorderedBlock(const char* name) { return OpenBlock(name, 0, true, ArchiveBlockType::Unordered); }
 
-    /// @}
+    /// \}
 };
 
 /// Archive implementation helper. Provides default Archive implementation for most cases.

--- a/Source/Urho3D/UI/UI.h
+++ b/Source/Urho3D/UI/UI.h
@@ -171,10 +171,10 @@ public:
 
     /// Return UI element double click interval in seconds.
     float GetDoubleClickInterval() const { return doubleClickInterval_; }
-    
-    /// Get max screen distance in pixels for double clicks to register. 
+
+    /// Get max screen distance in pixels for double clicks to register.
     float GetMaxDoubleClickDistance() const { return maxDoubleClickDist_;}
-    
+
     /// Return UI drag start event interval in seconds.
     float GetDragBeginInterval() const { return dragBeginInterval_; }
 
@@ -270,6 +270,8 @@ private:
     void GetElementAt(UIElement*& result, UIElement* current, const IntVector2& position, bool enabledOnly);
     /// Return the first element in hierarchy that can alter focus.
     UIElement* GetFocusableElement(UIElement* element);
+    /// Return the first element in hierarchy that can handle wheel.
+    UIElement* GetWheelHandlerElement(UIElement* element);
     /// Return cursor position and visibility either from the cursor element, or the Input subsystem.
     void GetCursorPositionAndVisible(IntVector2& pos, bool& visible);
     /// Set active cursor's shape.
@@ -296,7 +298,7 @@ private:
 
     /// Send a UI double click event
     void SendDoubleClickEvent(UIElement* beginElement, UIElement* endElement, const IntVector2& firstPos, const IntVector2& secondPos, MouseButton button, MouseButtonFlags buttons, QualifierFlags qualifiers);
-    
+
     /// Handle screen mode event.
     void HandleScreenMode(StringHash eventType, VariantMap& eventData);
     /// Handle mouse button down event.


### PR DESCRIPTION
On Windows, mouse wheel doesn't work if child is selected even if parent can handle wheel.
I think it's better to redirect wheel into element that can actually handle it, not just nearest "focusable" element.