### PR TITLE
Editor: add Sound Inspector

### DIFF
--- a/Source/Tools/Editor/Editor.cpp
+++ b/Source/Tools/Editor/Editor.cpp
@@ -38,6 +38,7 @@
 #include <Urho3D/SystemUI/DebugHud.h>
 #include <Urho3D/LibraryInfo.h>
 #include <Urho3D/Core/CommandLine.h>
+#include <Urho3D/Audio/Sound.h>
 
 #include <Toolbox/ToolboxAPI.h>
 #include <Toolbox/SystemUI/Widgets.h>
@@ -67,6 +68,7 @@
 #include "Inspector/ModelInspector.h"
 #include "Inspector/NodeInspector.h"
 #include "Inspector/SerializableInspector.h"
+#include "Inspector/SoundInspector.h"
 #include "Tabs/ProfilerTab.h"
 
 namespace Urho3D
@@ -173,6 +175,7 @@ void Editor::Setup()
     RegisterProvider<Asset, AssetInspector>();
     RegisterProvider<Model, ModelInspector>();
     RegisterProvider<Material, MaterialInspector>();
+    RegisterProvider<Sound, SoundInspector>();
     RegisterProvider<Node, NodeInspector>();
 
 #if URHO3D_PLUGINS

--- a/Source/Tools/Editor/Inspector/SoundInspector.cpp
+++ b/Source/Tools/Editor/Inspector/SoundInspector.cpp
@@ -46,6 +46,21 @@ void SoundInspector::RenderInspector(const char* filter)
         if (Sound* asset = dynamic_cast<Sound*>(self.Get()))
         {
             ui::Text(asset->GetName().c_str());
+
+            ui::Separator();
+
+            ui::Text("Frequency %u", (unsigned)asset->GetFrequency());
+            ui::Text(asset->IsStereo() ? "Stereo" : "Mono");
+            if (asset->IsSixteenBit())
+            {
+                ui::SameLine();
+                ui::Text(", 16-bit");
+            }
+            if (asset->IsCompressed())
+                ui::Text("Compressed");
+            if (asset->IsLooped())
+                ui::Text("Loop Start: %ull", asset->GetRepeat() - asset->GetStart());
+
             if (ui::Button(ICON_FA_PLAY " Play"))
             {
                 playingSource_.Reset(new SoundSource(context_));

--- a/Source/Tools/Editor/Inspector/SoundInspector.cpp
+++ b/Source/Tools/Editor/Inspector/SoundInspector.cpp
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2020 the rbfx project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "AssetInspector.h"
+#include "Pipeline/Asset.h"
+#include "Inspector/SoundInspector.h"
+#include <IconFontCppHeaders/IconsFontAwesome5.h>
+
+#include <Urho3D/Audio/Audio.h>
+#include <Urho3D/Audio/Sound.h>
+#include <Urho3D/Audio/SoundSource.h>
+
+#include <Urho3D/SystemUI/SystemUI.h>
+
+namespace Urho3D
+{
+
+SoundInspector::~SoundInspector()
+{
+    StopPlaying();
+}
+
+void SoundInspector::RenderInspector(const char* filter)
+{
+    if (auto self = inspected_.Lock())
+    {
+        if (Sound* asset = dynamic_cast<Sound*>(self.Get()))
+        {
+            ui::Text(asset->GetName().c_str());
+            if (ui::Button(ICON_FA_PLAY " Play"))
+            {
+                playingSource_.Reset(new SoundSource(context_));
+                playingSource_->Play(asset);
+            }
+            ui::SameLine();
+            if (ui::Button(ICON_FA_STOP " Stop"))
+            {
+                if (playingSource_)
+                    playingSource_->Stop();
+                playingSource_.Reset();
+            }
+            if (playingSource_)
+            {
+                float pos = playingSource_->GetTimePosition();
+                if (ui::SliderFloat("##time", &pos, 0.0f, asset->GetLength()))
+                    playingSource_->Seek(Max(Min(pos, asset->GetLength()), 0.0f));
+                if (!playingSource_->IsPlaying())
+                    playingSource_->Seek(0);
+            }
+        }
+    }
+}
+
+void SoundInspector::ClearSelection()
+{
+    StopPlaying();
+}
+
+void SoundInspector::StopPlaying()
+{
+    if (playingSource_)
+    {
+        playingSource_->Stop();
+        playingSource_.Reset();
+    }
+}
+
+}

--- a/Source/Tools/Editor/Inspector/SoundInspector.cpp
+++ b/Source/Tools/Editor/Inspector/SoundInspector.cpp
@@ -45,19 +45,19 @@ void SoundInspector::RenderInspector(const char* filter)
     {
         if (Sound* asset = dynamic_cast<Sound*>(self.Get()))
         {
-            ui::Text(asset->GetName().c_str());
+            ui::TextUnformatted(asset->GetName().c_str());
 
             ui::Separator();
 
             ui::Text("Frequency %u", (unsigned)asset->GetFrequency());
-            ui::Text(asset->IsStereo() ? "Stereo" : "Mono");
+            ui::TextUnformatted(asset->IsStereo() ? "Stereo" : "Mono");
             if (asset->IsSixteenBit())
             {
                 ui::SameLine();
-                ui::Text(", 16-bit");
+                ui::TextUnformatted(", 16-bit");
             }
             if (asset->IsCompressed())
-                ui::Text("Compressed");
+                ui::TextUnformatted("Compressed");
             if (asset->IsLooped())
                 ui::Text("Loop Start: %ull", asset->GetRepeat() - asset->GetStart());
 
@@ -75,6 +75,8 @@ void SoundInspector::RenderInspector(const char* filter)
             }
             if (playingSource_)
             {
+                ui::SameLine();
+
                 float pos = playingSource_->GetTimePosition();
                 if (ui::SliderFloat("##time", &pos, 0.0f, asset->GetLength()))
                     playingSource_->Seek(Max(Min(pos, asset->GetLength()), 0.0f));

--- a/Source/Tools/Editor/Inspector/SoundInspector.cpp
+++ b/Source/Tools/Editor/Inspector/SoundInspector.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 the rbfx project.
+// Copyright (c) 2017-2020 the rbfx project.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Source/Tools/Editor/Inspector/SoundInspector.h
+++ b/Source/Tools/Editor/Inspector/SoundInspector.h
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2020 the rbfx project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+#include "Inspector/InspectorProvider.h"
+
+#include <Urho3D/Audio/SoundSource.h>
+
+namespace Urho3D
+{
+
+struct InspectArgs;
+
+class SoundInspector : public InspectorProvider
+{
+    URHO3D_OBJECT(SoundInspector, InspectorProvider);
+public:
+    /// Construct.
+    explicit SoundInspector(Context* context) : InspectorProvider(context) { }
+    /// Destruct.
+    virtual ~SoundInspector();
+
+    /// Render inspector UI.
+    virtual void RenderInspector(const char* filter) override;
+    /// Release associated resources.
+    virtual void ClearSelection() override;
+
+protected:
+    void StopPlaying();
+
+    SharedPtr<SoundSource> playingSource_;
+};
+
+}

--- a/Source/Tools/Editor/Inspector/SoundInspector.h
+++ b/Source/Tools/Editor/Inspector/SoundInspector.h
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 the rbfx project.
+// Copyright (c) 2017-2020 the rbfx project.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Source/Urho3D/Audio/SoundSource.cpp
+++ b/Source/Urho3D/Audio/SoundSource.cpp
@@ -328,7 +328,7 @@ void SoundSource::SetPlayPosition(signed char* pos)
 
 void SoundSource::Update(float timeStep)
 {
-    if (!audio_ || !IsEnabledEffective())
+    if (!audio_ || (!IsEnabledEffective() && node_ != nullptr))
         return;
 
     // If there is no actual audio output, perform fake mixing into a nonexistent buffer to check stopping/looping
@@ -341,7 +341,7 @@ void SoundSource::Update(float timeStep)
 
     bool playing = IsPlaying();
 
-    if (!playing && sendFinishedEvent_)
+    if (!playing && sendFinishedEvent_ && node_ != nullptr)
     {
         sendFinishedEvent_ = false;
 
@@ -365,7 +365,7 @@ void SoundSource::Update(float timeStep)
 
 void SoundSource::Mix(int dest[], unsigned samples, int mixRate, bool stereo, bool interpolation)
 {
-    if (!position_ || (!sound_ && !soundStream_) || !IsEnabledEffective())
+    if (!position_ || (!sound_ && !soundStream_) || (!IsEnabledEffective() && node_ != nullptr))
         return;
 
     int streamFilledSize, outBytes;


### PR DESCRIPTION
Adds a minimal sound inspector that just has trivial playback handling along with some basic information.

![image](https://user-images.githubusercontent.com/5519639/73709095-2703f700-46ce-11ea-9048-fe0da7bd8653.png)

Changes made to `SoundSource` in order to support using SoundSources without them being attached to Nodes (similar to how `Camera` can be used without a node). Sound playback in the sound inspector is one use case.