### PR TITLE
Fix SetSize returning too early in constructor

### DIFF
--- a/Source/Tools/Toolbox/Graphics/SceneView.cpp
+++ b/Source/Tools/Toolbox/Graphics/SceneView.cpp
@@ -36,12 +36,11 @@ namespace Urho3D
 {
 
 SceneView::SceneView(Context* context, const IntRect& rect)
-    : rect_(rect)
+    : rect_()
 {
     scene_ = SharedPtr<Scene>(new Scene(context));
     scene_->CreateComponent<Octree>();
     viewport_ = SharedPtr<Viewport>(new Viewport(context, scene_, nullptr));
-    viewport_->SetRect(IntRect(IntVector2::ZERO, rect_.Size()));
     CreateObjects();
     texture_ = SharedPtr<Texture2D>(new Texture2D(context));
     // Make sure viewport is not using default renderpath. That would cause issues when renderpath


### PR DESCRIPTION
I tried rendering the SceneView with a fixed size and realized it wouldn't render unless I forced a size change.

The code in SetSize was never called in the constructor because the rect_ property would be initialized too early. This would prevent the initial setup from happening and for fixed sizes would result in an empty texture.