### PR TITLE
Fix out of range bug in DebugHUD when changing shadow quality.

### DIFF
--- a/Source/Urho3D/SystemUI/DebugHud.cpp
+++ b/Source/Urho3D/SystemUI/DebugHud.cpp
@@ -53,7 +53,9 @@ static const char* shadowQualityTexts[] =
     "16bit Low",
     "24bit Low",
     "16bit High",
-    "24bit High"
+    "24bit High",
+    "VSM",
+    "Blur VSM"
 };
 
 static const unsigned FPS_UPDATE_INTERVAL_MS = 500;


### PR DESCRIPTION
Some of the values from ShadowQuality enum are not covered by shadowQualityTexts  array when used in RenderUI method.

This statement:
```cpp
        ui::Text("Tex:%s | Mat:%s | Spec:%s | Shadows:%s | Size:%i | Quality:%s | Occlusion:%s | Instancing:%s | API:%s",
            //...
            shadowQualityTexts[renderer->GetShadowQuality()],
            //...
```

Affected by:
```cpp
// Source/Urho3D/Graphics/GraphicsDefs.h
enum ShadowQuality
{
    SHADOWQUALITY_SIMPLE_16BIT = 0,
    SHADOWQUALITY_SIMPLE_24BIT,
    SHADOWQUALITY_PCF_16BIT,
    SHADOWQUALITY_PCF_24BIT,
    SHADOWQUALITY_VSM,
    SHADOWQUALITY_BLUR_VSM
};
```