### PR TITLE
Inheritance replaced with composition in BinaryFile

### DIFF
--- a/Source/Urho3D/Resource/BinaryFile.cpp
+++ b/Source/Urho3D/Resource/BinaryFile.cpp
@@ -49,14 +49,14 @@ void BinaryFile::RegisterObject(Context* context)
 bool BinaryFile::BeginLoad(Deserializer& source)
 {
     source.Seek(0);
-    VectorBuffer::SetData(source, source.GetSize());
-    SetMemoryUse(VectorBuffer::GetBuffer().capacity());
+    buffer_.SetData(source, source.GetSize());
+    SetMemoryUse(buffer_.GetBuffer().capacity());
     return true;
 }
 
 bool BinaryFile::Save(Serializer& dest) const
 {
-    if (dest.Write(VectorBuffer::GetData(), VectorBuffer::GetSize()) != VectorBuffer::GetSize())
+    if (dest.Write(buffer_.GetData(), buffer_.GetSize()) != buffer_.GetSize())
     {
         URHO3D_LOGERROR("Can not save binary file" + GetName());
         return false;
@@ -76,18 +76,18 @@ bool BinaryFile::SaveFile(const ea::string& fileName) const
 
 void BinaryFile::Clear()
 {
-    VectorBuffer::Clear();
+    buffer_.Clear();
 }
 
 void BinaryFile::SetData(const ByteVector& data)
 {
-    VectorBuffer::SetData(data);
-    SetMemoryUse(VectorBuffer::GetBuffer().capacity());
+    buffer_.SetData(data);
+    SetMemoryUse(buffer_.GetBuffer().capacity());
 }
 
 const ByteVector& BinaryFile::GetData() const
 {
-    return VectorBuffer::GetBuffer();
+    return buffer_.GetBuffer();
 }
 
 }

--- a/Source/Urho3D/Resource/BinaryFile.h
+++ b/Source/Urho3D/Resource/BinaryFile.h
@@ -33,7 +33,7 @@ namespace Urho3D
 {
 
 /// Resource for generic binary file.
-class URHO3D_API BinaryFile : public Resource, private VectorBuffer
+class URHO3D_API BinaryFile : public Resource
 {
     URHO3D_OBJECT(BinaryFile, Resource);
 
@@ -51,8 +51,6 @@ public:
     bool Save(Serializer& dest) const override;
     /// Save resource to a file.
     bool SaveFile(const ea::string& fileName) const override;
-    /// Return name of the stream.
-    const ea::string& GetName() const override { return Resource::GetName(); }
 
     /// Clear data.
     void Clear();
@@ -62,14 +60,16 @@ public:
     const ByteVector& GetData() const;
 
     /// Cast to Serializer.
-    Serializer& AsSerializer() { return *this; }
+    Serializer& AsSerializer() { return buffer_; }
     /// Cast to Deserializer.
-    Deserializer& AsDeserializer() { return *this; }
+    Deserializer& AsDeserializer() { return buffer_; }
 
     /// Create input archive that reads from the resource. Don't use more than one archive simultaneously.
-    BinaryInputArchive AsInputArchive() { return BinaryInputArchive(context_, *this); }
+    BinaryInputArchive AsInputArchive() { return BinaryInputArchive(context_, buffer_); }
     /// Create output archive that writes to the resource. Don't use more than one archive simultaneously.
-    BinaryOutputArchive AsOutputArchive() { return BinaryOutputArchive(context_, *this); }
+    BinaryOutputArchive AsOutputArchive() { return BinaryOutputArchive(context_, buffer_); }
+private:
+    VectorBuffer buffer_;
 };
 
 }


### PR DESCRIPTION
There is no reason to have VectorBuffer as a base type. BinaryFile isn't used as an AbstractFile so it's fine have the VectorBuffer as a field.

Just something I spotted while refactoring AbstractFile.