### PR TITLE
ConstantBufferSizes

### DIFF
--- a/Source/Urho3D/Graphics/Direct3D11/D3D11ShaderProgram.h
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11ShaderProgram.h
@@ -40,15 +40,15 @@ public:
     ShaderProgram(Graphics* graphics, ShaderVariation* vertexShader, ShaderVariation* pixelShader)
     {
         // Create needed constant buffers
-        const unsigned* vsBufferSizes = vertexShader->GetConstantBufferSizes();
-        for (unsigned i = 0; i < MAX_SHADER_PARAMETER_GROUPS; ++i)
+        const ShaderVariation::ConstantBufferSizes& vsBufferSizes = vertexShader->GetConstantBufferSizes();
+        for (unsigned i = 0; i < vsBufferSizes.size(); ++i)
         {
             if (vsBufferSizes[i])
                 AddConstantBuffer(static_cast<ShaderParameterGroup>(i), vsBufferSizes[i]);
         }
 
-        const unsigned* psBufferSizes = pixelShader->GetConstantBufferSizes();
-        for (unsigned i = 0; i < MAX_SHADER_PARAMETER_GROUPS; ++i)
+        const ShaderVariation::ConstantBufferSizes& psBufferSizes = pixelShader->GetConstantBufferSizes();
+        for (unsigned i = 0; i < psBufferSizes.size(); ++i)
         {
             if (psBufferSizes[i])
                 AddConstantBuffer(static_cast<ShaderParameterGroup>(i), psBufferSizes[i]);

--- a/Source/Urho3D/Graphics/ShaderVariation.h
+++ b/Source/Urho3D/Graphics/ShaderVariation.h
@@ -81,6 +81,8 @@ struct URHO3D_API ShaderParameter
 class URHO3D_API ShaderVariation : public RefCounted, public GPUObject
 {
 public:
+    typedef ea::array<unsigned, MAX_SHADER_PARAMETER_GROUPS> ConstantBufferSizes;
+
     /// Construct.
     ShaderVariation(Shader* owner, ShaderType type);
     /// Destruct.
@@ -132,7 +134,7 @@ public:
     const ea::string& GetCompilerOutput() const { return compilerOutput_; }
 
     /// Return constant buffer data sizes.
-    const unsigned* GetConstantBufferSizes() const { return &constantBufferSizes_[0]; }
+    const ConstantBufferSizes& GetConstantBufferSizes() const { return constantBufferSizes_; }
 
     /// D3D11 vertex semantic names. Used internally.
     static const char* elementSemanticNames[];
@@ -160,7 +162,7 @@ private:
     /// Texture unit use flags.
     bool useTextureUnits_[MAX_TEXTURE_UNITS]{};
     /// Constant buffer sizes. 0 if a constant buffer slot is not in use.
-    unsigned constantBufferSizes_[MAX_SHADER_PARAMETER_GROUPS]{};
+    ConstantBufferSizes constantBufferSizes_{};
     /// Shader bytecode. Needed for inspecting the input signature and parameters. Not used on OpenGL.
     ea::vector<unsigned char> byteCode_;
     /// Shader name.


### PR DESCRIPTION
unsigned* replaced with ea::array.

ea::array is a lightweight wrap on top of array so it doesn't have overhead. At the same time it defines exact underlying array size so it is obvious how to use the return value for anyone who isn't familiar with the code.

Also it should help with .net wrapper.