### PR TITLE
Refactor animation controller

### DIFF
--- a/Source/Samples/06_SkeletalAnimation/Mover.cpp
+++ b/Source/Samples/06_SkeletalAnimation/Mover.cpp
@@ -52,13 +52,4 @@ void Mover3D::Update(float timeStep)
     Vector3 pos = node_->GetPosition();
     if (pos.x_ < bounds_.min_.x_ || pos.x_ > bounds_.max_.x_ || pos.z_ < bounds_.min_.z_ || pos.z_ > bounds_.max_.z_)
         node_->Yaw(rotationSpeed_ * timeStep);
-
-    // Get the model's first (only) animation state and advance its time. Note the convenience accessor to other components
-    // in the same scene node
-    auto* model = node_->GetComponent<AnimatedModel>(true);
-    if (model->GetNumAnimationStates())
-    {
-        AnimationState* state = model->GetAnimationStates()[0];
-        state->AddTime(timeStep);
-    }
 }

--- a/Source/Samples/06_SkeletalAnimation/SkeletalAnimation.cpp
+++ b/Source/Samples/06_SkeletalAnimation/SkeletalAnimation.cpp
@@ -24,6 +24,7 @@
 #include <Urho3D/Engine/Engine.h>
 #include <Urho3D/Graphics/AnimatedModel.h>
 #include <Urho3D/Graphics/Animation.h>
+#include <Urho3D/Graphics/AnimationController.h>
 #include <Urho3D/Graphics/AnimationState.h>
 #include <Urho3D/Graphics/Camera.h>
 #include <Urho3D/Graphics/DebugRenderer.h>
@@ -133,17 +134,12 @@ void SkeletalAnimation::CreateScene()
         // Create an AnimationState for a walk animation. Its time position will need to be manually updated to advance the
         // animation, The alternative would be to use an AnimationController component which updates the animation automatically,
         // but we need to update the model's position manually in any case
-        auto* walkAnimation = cache->GetResource<Animation>("Models/Kachujin/Kachujin_Walk.ani");
+        const ea::string walkAnimationName = "Models/Kachujin/Kachujin_Walk.ani";
+        auto* walkAnimation = cache->GetResource<Animation>(walkAnimationName);
 
-        AnimationState* state = modelObject->AddAnimationState(walkAnimation);
-        // The state would fail to create (return null) if the animation was not found
-        if (state)
-        {
-            // Enable full blending weight and looping
-            state->SetWeight(1.0f);
-            state->SetLooped(true);
-            state->SetTime(Random(walkAnimation->GetLength()));
-        }
+        auto animationController = modelNode->CreateComponent<AnimationController>();
+        animationController->Play(walkAnimationName, 0, true);
+        animationController->SetTime(walkAnimationName, Random(walkAnimation->GetLength()));
 
         // Create our custom Mover3D component that will move & animate the model during each frame's update
         auto* mover = modelNode->CreateComponent<Mover3D>();

--- a/Source/Samples/30_LightAnimation/LightAnimation.cpp
+++ b/Source/Samples/30_LightAnimation/LightAnimation.cpp
@@ -22,6 +22,7 @@
 
 #include <Urho3D/Core/CoreEvents.h>
 #include <Urho3D/Engine/Engine.h>
+#include <Urho3D/Graphics/AnimationController.h>
 #include <Urho3D/Graphics/Camera.h>
 #include <Urho3D/Graphics/Graphics.h>
 #include <Urho3D/Graphics/Material.h>
@@ -31,7 +32,6 @@
 #include <Urho3D/Graphics/StaticModel.h>
 #include <Urho3D/Input/Input.h>
 #include <Urho3D/Resource/ResourceCache.h>
-#include <Urho3D/Scene/ObjectAnimation.h>
 #include <Urho3D/Scene/Scene.h>
 #include <Urho3D/Scene/ValueAnimation.h>
 #include <Urho3D/UI/Font.h>
@@ -97,22 +97,9 @@ void LightAnimation::CreateScene()
     light->SetLightType(LIGHT_POINT);
     light->SetRange(10.0f);
 
-    // Create light animation
-    SharedPtr<ObjectAnimation> lightAnimation(new ObjectAnimation(context_));
-
-    // Create light position animation
-    SharedPtr<ValueAnimation> positionAnimation(new ValueAnimation(context_));
-    // Use spline interpolation method
-    positionAnimation->SetInterpolationMethod(IM_SPLINE);
-    // Set spline tension
-    positionAnimation->SetSplineTension(0.7f);
-    positionAnimation->SetKeyFrame(0.0f, Vector3(-30.0f, 5.0f, -30.0f));
-    positionAnimation->SetKeyFrame(1.0f, Vector3( 30.0f, 5.0f, -30.0f));
-    positionAnimation->SetKeyFrame(2.0f, Vector3( 30.0f, 5.0f,  30.0f));
-    positionAnimation->SetKeyFrame(3.0f, Vector3(-30.0f, 5.0f,  30.0f));
-    positionAnimation->SetKeyFrame(4.0f, Vector3(-30.0f, 5.0f, -30.0f));
-    // Set position animation
-    lightAnimation->AddAttributeAnimation("Position", positionAnimation);
+    // Apply light animation to light node
+    auto* animationController = lightNode->CreateComponent<AnimationController>();
+    animationController->Play("Animations/LightAnimation.xml", 0, true);
 
     // Create text animation
     SharedPtr<ValueAnimation> textAnimation(new ValueAnimation(context_));
@@ -133,19 +120,6 @@ void LightAnimation::CreateScene()
     spriteAnimation->SetKeyFrame(0.4f, ResourceRef("Texture2D", "Urho2D/GoldIcon/5.png"));
     spriteAnimation->SetKeyFrame(0.5f, ResourceRef("Texture2D", "Urho2D/GoldIcon/1.png"));
     GetSubsystem<UI>()->GetRoot()->GetChild(ea::string("animatingSprite"))->SetAttributeAnimation("Texture", spriteAnimation);
-
-    // Create light color animation
-    SharedPtr<ValueAnimation> colorAnimation(new ValueAnimation(context_));
-    colorAnimation->SetKeyFrame(0.0f, Color::WHITE);
-    colorAnimation->SetKeyFrame(1.0f, Color::RED);
-    colorAnimation->SetKeyFrame(2.0f, Color::YELLOW);
-    colorAnimation->SetKeyFrame(3.0f, Color::GREEN);
-    colorAnimation->SetKeyFrame(4.0f, Color::WHITE);
-    // Set Light component's color animation
-    lightAnimation->AddAttributeAnimation("@Light/Color", colorAnimation);
-
-    // Apply light animation to light node
-    lightNode->SetObjectAnimation(lightAnimation);
 
     // Create more StaticModel objects to the scene, randomly positioned, rotated and scaled. For rotation, we construct a
     // quaternion from Euler angles where the Y angle (rotation about the Y axis) is randomized. The mushroom model contains

--- a/Source/Tests/CommonUtils.cpp
+++ b/Source/Tests/CommonUtils.cpp
@@ -56,13 +56,4 @@ void RunFrame(Context* context, float timeStep, float maxTimeStep)
     while (timeStep > 0.0f);
 }
 
-void SerializeAndDeserializeScene(Scene* scene)
-{
-    auto xmlFile = MakeShared<XMLFile>(scene->GetContext());
-    auto xmlRoot = xmlFile->GetOrCreateRoot("scene");
-    scene->SaveXML(xmlRoot);
-    scene->Clear();
-    scene->LoadXML(xmlRoot);
-}
-
 }

--- a/Source/Tests/CommonUtils.cpp
+++ b/Source/Tests/CommonUtils.cpp
@@ -26,6 +26,7 @@
 
 #include <Urho3D/Engine/Engine.h>
 #include <Urho3D/Engine/EngineDefs.h>
+#include <Urho3D/Resource/XMLFile.h>
 
 namespace Tests
 {
@@ -53,6 +54,15 @@ void RunFrame(Context* context, float timeStep, float maxTimeStep)
         timeStep -= subTimeStep;
     }
     while (timeStep > 0.0f);
+}
+
+void SerializeAndDeserializeScene(Scene* scene)
+{
+    auto xmlFile = MakeShared<XMLFile>(scene->GetContext());
+    auto xmlRoot = xmlFile->GetOrCreateRoot("scene");
+    scene->SaveXML(xmlRoot);
+    scene->Clear();
+    scene->LoadXML(xmlRoot);
 }
 
 }

--- a/Source/Tests/CommonUtils.h
+++ b/Source/Tests/CommonUtils.h
@@ -25,6 +25,7 @@
 #include <Urho3D/Core/Context.h>
 #include <Urho3D/Core/Variant.h>
 #include <Urho3D/Container/Ptr.h>
+#include <Urho3D/Scene/Scene.h>
 
 #include <catch2/catch_amalgamated.hpp>
 #include <ostream>
@@ -39,6 +40,9 @@ SharedPtr<Context> CreateCompleteTestContext();
 
 /// Run frame with given time step.
 void RunFrame(Context* context, float timeStep, float maxTimeStep = M_LARGE_VALUE);
+
+/// Serialize and deserialize Scene. Should preserve functional state of nodes and components.
+void SerializeAndDeserializeScene(Scene* scene);
 
 }
 

--- a/Source/Tests/ModelUtils.cpp
+++ b/Source/Tests/ModelUtils.cpp
@@ -96,6 +96,42 @@ AnimationKeyFrame MakeRotationKeyFrame(float time, const Quaternion& rotation)
     return keyFrame;
 }
 
+SharedPtr<Animation> CreateLoopedTranslationAnimation(Context* context,
+    const ea::string& animationName, const ea::string& boneName,
+    const Vector3& origin, const Vector3& magnitude, float duration)
+{
+    auto animation = MakeShared<Animation>(context);
+    animation->SetName(animationName);
+    animation->SetLength(duration);
+
+    auto track = animation->CreateTrack(boneName);
+    track->channelMask_ = CHANNEL_POSITION;
+
+    track->AddKeyFrame(MakeTranslationKeyFrame(duration * 0.0f, origin));
+    track->AddKeyFrame(MakeTranslationKeyFrame(duration * 0.25f, origin - magnitude));
+    track->AddKeyFrame(MakeTranslationKeyFrame(duration * 0.75f, origin + magnitude));
+    track->AddKeyFrame(MakeTranslationKeyFrame(duration * 1.0f, origin));
+
+    return animation;
+}
+
+SharedPtr<Animation> CreateLoopedRotationAnimation(Context* context,
+    const ea::string& animationName, const ea::string& boneName,
+    const Vector3& axis, float duration)
+{
+    auto animation = MakeShared<Animation>(context);
+    animation->SetName(animationName);
+    animation->SetLength(duration);
+
+    auto track = animation->CreateTrack(boneName);
+    track->channelMask_ = CHANNEL_ROTATION;
+
+    for (int i = 0; i <= 4; ++i)
+        track->AddKeyFrame(MakeRotationKeyFrame(duration * i * 0.25f, { i * 90.0f, axis }));
+
+    return animation;
+}
+
 SharedPtr<ModelView> CreateSkinnedQuad_Model(Context* context)
 {
     auto modelView = MakeShared<ModelView>(context);
@@ -143,55 +179,4 @@ SharedPtr<ModelView> CreateSkinnedQuad_Model(Context* context)
     return modelView;
 }
 
-SharedPtr<Animation> CreateSkinnedQuad_Animation_2TX(Context* context)
-{
-    auto animation = MakeShared<Animation>(context);
-    animation->SetName("@/Models/SkinnedQuad_2TX.ani");
-    animation->SetLength(2.0f);
-
-    auto track = animation->CreateTrack("Quad 2");
-    track->channelMask_ = CHANNEL_POSITION;
-
-    track->AddKeyFrame(MakeTranslationKeyFrame(0.0f, { 0.0f, 1.0f, 0.0f }));
-    track->AddKeyFrame(MakeTranslationKeyFrame(0.5f, { -0.5f, 1.0f, 0.0f }));
-    track->AddKeyFrame(MakeTranslationKeyFrame(1.5f, { 0.5f, 1.0f, 0.0f }));
-    track->AddKeyFrame(MakeTranslationKeyFrame(2.0f, { 0.0f, 1.0f, 0.0f }));
-
-    return animation;
-}
-
-SharedPtr<Animation> CreateSkinnedQuad_Animation_2TZ(Context* context)
-{
-    auto animation = MakeShared<Animation>(context);
-    animation->SetName("@/Models/SkinnedQuad_2TZ.ani");
-    animation->SetLength(2.0f);
-
-    auto track = animation->CreateTrack("Quad 2");
-    track->channelMask_ = CHANNEL_POSITION;
-
-    track->AddKeyFrame(MakeTranslationKeyFrame(0.0f, { 0.0f, 1.0f, 0.0f }));
-    track->AddKeyFrame(MakeTranslationKeyFrame(0.5f, { 0.0f, 1.0f, -0.5f }));
-    track->AddKeyFrame(MakeTranslationKeyFrame(1.5f, { 0.0f, 1.0f, 0.5f }));
-    track->AddKeyFrame(MakeTranslationKeyFrame(2.0f, { 0.0f, 1.0f, 0.0f }));
-
-    return animation;
-}
-
-SharedPtr<Animation> CreateSkinnedQuad_Animation_1RY(Context* context)
-{
-    auto animation = MakeShared<Animation>(context);
-    animation->SetName("@/Models/SkinnedQuad_1RY.ani");
-    animation->SetLength(1.0f);
-
-    auto track = animation->CreateTrack("Quad 1");
-    track->channelMask_ = CHANNEL_ROTATION;
-
-    track->AddKeyFrame(MakeRotationKeyFrame(0.0f, { 0.0f, Vector3::UP }));
-    track->AddKeyFrame(MakeRotationKeyFrame(0.25f, { 90.0f, Vector3::UP }));
-    track->AddKeyFrame(MakeRotationKeyFrame(0.5f, { 180.0f, Vector3::UP }));
-    track->AddKeyFrame(MakeRotationKeyFrame(0.75f, { -90.0f, Vector3::UP }));
-    track->AddKeyFrame(MakeRotationKeyFrame(1.0f, { 0.0f, Vector3::UP }));
-
-    return animation;
-}
 }

--- a/Source/Tests/ModelUtils.h
+++ b/Source/Tests/ModelUtils.h
@@ -43,6 +43,12 @@ void AppendSkinnedQuad(GeometryLODView& dest, const Vector4& blendIndices, const
 /// @{
 AnimationKeyFrame MakeTranslationKeyFrame(float time, const Vector3& position);
 AnimationKeyFrame MakeRotationKeyFrame(float time, const Quaternion& rotation);
+SharedPtr<Animation> CreateLoopedTranslationAnimation(Context* context,
+    const ea::string& animationName, const ea::string& boneName,
+    const Vector3& origin, const Vector3& magnitude, float duration);
+SharedPtr<Animation> CreateLoopedRotationAnimation(Context* context,
+    const ea::string& animationName, const ea::string& boneName,
+    const Vector3& axis, float duration);
 /// @}
 
 /// Create test skinned model:
@@ -50,18 +56,5 @@ AnimationKeyFrame MakeRotationKeyFrame(float time, const Quaternion& rotation);
 /// |-1: First 1x1 quad at Y=0.5;
 ///   |-2: Second 1x1 quad at Y=1.5.
 SharedPtr<ModelView> CreateSkinnedQuad_Model(Context* context);
-
-/// Create animations for test skinned model
-/// @{
-
-/// [1]: Move second quad at X axis in range [-1, 1] for 2 seconds.
-SharedPtr<Animation> CreateSkinnedQuad_Animation_2TX(Context* context);
-/// [1]: Move second quad at Z axis in range [-1, 1] for 2 seconds.
-SharedPtr<Animation> CreateSkinnedQuad_Animation_2TZ(Context* context);
-/// [2]: Rotate first quad around Y axis for 1 second.
-SharedPtr<Animation> CreateSkinnedQuad_Animation_1RY(Context* context);
-
-/// @}
-
 
 }

--- a/Source/Tests/ModelUtils.h
+++ b/Source/Tests/ModelUtils.h
@@ -49,6 +49,8 @@ SharedPtr<Animation> CreateLoopedTranslationAnimation(Context* context,
 SharedPtr<Animation> CreateLoopedRotationAnimation(Context* context,
     const ea::string& animationName, const ea::string& boneName,
     const Vector3& axis, float duration);
+SharedPtr<Animation> CreateCombinedAnimation(Context* context,
+    const ea::string& animationName, std::initializer_list<Animation*> animations);
 /// @}
 
 /// Create test skinned model:

--- a/Source/Tests/Scene/AnimatedModel.cpp
+++ b/Source/Tests/Scene/AnimatedModel.cpp
@@ -30,6 +30,7 @@
 #include <Urho3D/Graphics/Octree.h>
 #include <Urho3D/Scene/Scene.h>
 #include <Urho3D/Resource/ResourceCache.h>
+#include <Urho3D/UI/Text3D.h>
 
 TEST_CASE("Lerp animation blending")
 {
@@ -343,4 +344,138 @@ TEST_CASE("Animation start bone")
         Tests::RunFrame(context, 1.0f, 0.05f);
         REQUIRE(quad2->GetWorldPosition().Equals({ 0.0f, 1.0f, 2.0f }, M_LARGE_EPSILON));
     }
+}
+
+TEST_CASE("Variant animation tracks")
+{
+    auto context = Tests::CreateCompleteTestContext();
+    auto cache = context->GetSubsystem<ResourceCache>();
+
+    // Prepare resources
+    auto model = Tests::CreateSkinnedQuad_Model(context)->ExportModel("@/SkinnedQuad.mdl");
+    cache->AddManualResource(model);
+
+    {
+        auto animation = MakeShared<Animation>(context);
+        animation->SetName("@/Animation1.ani");
+        animation->SetLength(1.0f);
+        {
+            AnimationTrack* track = animation->CreateTrack("Quad 2");
+            track->channelMask_ = CHANNEL_POSITION;
+
+            track->AddKeyFrame({ 0.0f, Vector3::ONE });
+            track->AddKeyFrame({ 0.6f, Vector3::ZERO });
+        }
+        {
+            VariantAnimationTrack* track = animation->CreateVariantTrack("Child Node/@Text3D/Text");
+            track->AddKeyFrame({ 0.0f, Variant("A") });
+            track->AddKeyFrame({ 0.4f, Variant("B") });
+            track->Commit();
+        }
+        {
+            VariantAnimationTrack* track = animation->CreateVariantTrack("Child Node/@Text3D/Font Size");
+            track->AddKeyFrame({ 0.0f, 10.0f });
+            track->AddKeyFrame({ 0.4f, 20.0f });
+            track->Commit();
+        }
+        {
+            VariantAnimationTrack* track = animation->CreateVariantTrack("@/Variables/Test");
+            track->AddKeyFrame({ 0.0f, Variant(10) });
+            track->AddKeyFrame({ 0.4f, Variant(20) });
+            track->Commit();
+        }
+        cache->AddManualResource(animation);
+    }
+    {
+        auto animation = MakeShared<Animation>(context);
+        animation->SetName("@/Animation2.ani");
+        animation->SetLength(1.0f);
+        {
+            VariantAnimationTrack* track = animation->CreateVariantTrack("Child Node/@Text3D/Font Size");
+            track->AddKeyFrame({ 0.0f, 20.0f });
+            track->AddKeyFrame({ 0.4f, 30.0f });
+            track->Commit();
+        }
+        {
+            VariantAnimationTrack* track = animation->CreateVariantTrack("@/Variables/Test");
+            track->AddKeyFrame({ 0.0f, Variant(20) });
+            track->AddKeyFrame({ 0.4f, Variant(30) });
+            track->Commit();
+        }
+        cache->AddManualResource(animation);
+    }
+    {
+        auto animation = MakeShared<Animation>(context);
+        animation->SetName("@/Animation3.ani");
+        animation->SetLength(1.0f);
+        {
+            VariantAnimationTrack* track = animation->CreateVariantTrack("Child Node/@Text3D/Font Size");
+            track->baseValue_ = 11.0f;
+            track->AddKeyFrame({ 0.0f, 12.0f });
+            track->AddKeyFrame({ 0.4f, 16.0f });
+            track->Commit();
+        }
+        {
+            VariantAnimationTrack* track = animation->CreateVariantTrack("@/Variables/Test");
+            track->baseValue_ = 11;
+            track->AddKeyFrame({ 0.0f, Variant(12) });
+            track->AddKeyFrame({ 0.4f, Variant(16) });
+            track->Commit();
+        }
+        cache->AddManualResource(animation);
+    }
+
+    // Setup
+    auto scene = MakeShared<Scene>(context);
+    {
+        scene->CreateComponent<Octree>();
+
+        auto node = scene->CreateChild("Root Node");
+        node->SetPosition({ 0.0f, 1.0f, 0.0f });
+        auto animatedModel = node->CreateComponent<AnimatedModel>();
+        animatedModel->SetModel(model);
+
+        auto childNode = node->CreateChild("Child Node");
+        auto text = childNode->CreateComponent<Text3D>();
+
+        auto animationController = node->CreateComponent<AnimationController>();
+        animationController->Play("@/Animation1.ani", 0, false);
+        animationController->Play("@/Animation2.ani", 1, false);
+        animationController->SetWeight("@/Animation2.ani", 0.5f);
+        animationController->Play("@/Animation3.ani", 2, false);
+        animationController->SetBlendMode("@/Animation3.ani", ABM_ADDITIVE);
+        animationController->SetWeight("@/Animation3.ani", 0.5f);
+    }
+
+    // Assert
+    Tests::NodeRef rootNode{ scene, "Root Node" };
+    Tests::NodeRef quad2{ scene, "Quad 2" };
+    Tests::ComponentRef<Text3D> childNodeText{ scene, "Child Node" };
+
+    // [Time = 0.3]
+    // Quad 2: Translate to 0.5
+    // Test:
+    // - Animation1: Lerp(10, 20, 0.75) = 17(.5)
+    // - Animation2: Lerp(20, 30, 0.75) = 27(.5)
+    // - Animation3: Lerp(12, 16, 0.75) - 11 = 4
+    // - Final: Lerp(Animation1, Animation2, 0.5) + Animation3 * 0.5 = 24(.5)
+    Tests::RunFrame(context, 0.3f, 0.5f);
+    REQUIRE(quad2->GetWorldPosition().Equals({ 0.5f, 1.5f, 0.5f }, M_LARGE_EPSILON));
+    REQUIRE(rootNode->GetVar("Test") == Variant(24));
+    REQUIRE(childNodeText->GetFontSize() == 24.5f);
+    REQUIRE(childNodeText->GetText() == "A");
+
+    // [Time = 1.0]
+    // Quad 2: Translate X to 0
+    // Test:
+    // - Animation1: Lerp(10, 20, 1.0) = 20
+    // - Animation2: Lerp(20, 30, 1.0) = 30
+    // - Animation3: Lerp(12, 16, 1.0) - 11 = 5
+    // - Final: Lerp(Animation1, Animation2, 0.5) + Animation3 * 0.5 = 27(.5)
+    Tests::SerializeAndDeserializeScene(scene);
+    Tests::RunFrame(context, 0.3f, 0.5f);
+    REQUIRE(quad2->GetWorldPosition().Equals({ 0.0f, 1.0f, 0.0f }, M_LARGE_EPSILON));
+    REQUIRE(rootNode->GetVar("Test") == Variant(27));
+    REQUIRE(childNodeText->GetFontSize() == 27.5f);
+    REQUIRE(childNodeText->GetText() == "B");
 }

--- a/Source/Tests/Scene/Scene.cpp
+++ b/Source/Tests/Scene/Scene.cpp
@@ -1,0 +1,57 @@
+//
+// Copyright (c) 2017-2021 the rbfx project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR rhs
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR rhsWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR rhs DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "../CommonUtils.h"
+#include "../SceneUtils.h"
+
+#include <Urho3D/Graphics/StaticModel.h>
+
+TEST_CASE("Scene lookup")
+{
+    auto context = Tests::CreateCompleteTestContext();
+    auto scene = MakeShared<Scene>(context);
+
+    auto child0 = scene->CreateChild("Child_0");
+    auto child00 = child0->CreateChild("Child_0_0");
+    auto child000 = child00->CreateChild("Child_0_0_0");
+    auto child01 = child0->CreateChild("Child_0_1");
+    auto child1 = scene->CreateChild("Child_1");
+    auto child2 = scene->CreateChild("Child_2");
+    auto child20 = child2->CreateChild("Child_2_0");
+
+    child20->CreateComponent<StaticModel>();
+
+    CHECK(scene->GetChild("Child_0", true) == child0);
+    CHECK(scene->GetChild("Child_2_0", true) == child20);
+
+    CHECK(scene->FindChild("Child_0/Child_0_0/Child_0_0_0") == child000);
+    CHECK(scene->FindChild("#0/#0/#0") == child000);
+    CHECK(scene->FindChild("Child_0/Child_0_1") == child01);
+    CHECK(scene->FindChild("#0/#1") == child01);
+    CHECK(scene->FindChild("Child_2") == child2);
+    CHECK(scene->FindChild("#2") == child2);
+    CHECK(scene->FindChild("Child_2/Child_2_0") == child20);
+    CHECK(scene->FindChild("#2/#0") == child20);
+
+    CHECK(Tests::GetAttributeValue(child20->FindComponentAttribute("@/Name")) == Variant(child20->GetName()));
+    CHECK(Tests::GetAttributeValue(child20->FindComponentAttribute("@StaticModel/LOD Bias")) == Variant(1.0f));
+}

--- a/Source/Tests/SceneUtils.cpp
+++ b/Source/Tests/SceneUtils.cpp
@@ -22,46 +22,25 @@
 
 #pragma once
 
-#include <Urho3D/Core/Context.h>
-#include <Urho3D/Core/Variant.h>
-#include <Urho3D/Container/Ptr.h>
+#include "SceneUtils.h"
 
-#include <catch2/catch_amalgamated.hpp>
-#include <ostream>
-
-using namespace Urho3D;
+#include <Urho3D/Resource/XMLFile.h>
 
 namespace Tests
 {
 
-/// Create test context with all subsystems ready.
-SharedPtr<Context> CreateCompleteTestContext();
-
-/// Run frame with given time step.
-void RunFrame(Context* context, float timeStep, float maxTimeStep = M_LARGE_VALUE);
-
-}
-
-/// Convert common types to strings
-/// @{
-namespace Catch
+void SerializeAndDeserializeScene(Scene* scene)
 {
+    auto xmlFile = MakeShared<XMLFile>(scene->GetContext());
+    auto xmlRoot = xmlFile->GetOrCreateRoot("scene");
+    scene->SaveXML(xmlRoot);
+    scene->Clear();
+    scene->LoadXML(xmlRoot);
+}
 
-#define DEFINE_STRING_MAKER(type, expr) \
-    template<> struct StringMaker<type> \
-    { \
-        static std::string convert(const type& value) \
-        { \
-            return expr; \
-        } \
-    }
-
-DEFINE_STRING_MAKER(Variant, value.ToString().c_str());
-DEFINE_STRING_MAKER(Vector2, value.ToString().c_str());
-DEFINE_STRING_MAKER(Vector3, value.ToString().c_str());
-DEFINE_STRING_MAKER(Vector4, value.ToString().c_str());
-
-#undef DEFINE_STRING_MAKER
+Node* NodeRef::GetNode() const
+{
+    return scene_ ? scene_->GetChild(name_, true) : nullptr;
+}
 
 }
-/// @}

--- a/Source/Tests/SceneUtils.h
+++ b/Source/Tests/SceneUtils.h
@@ -22,46 +22,28 @@
 
 #pragma once
 
-#include <Urho3D/Core/Context.h>
-#include <Urho3D/Core/Variant.h>
-#include <Urho3D/Container/Ptr.h>
-
-#include <catch2/catch_amalgamated.hpp>
-#include <ostream>
+#include <Urho3D/Scene/Scene.h>
 
 using namespace Urho3D;
 
 namespace Tests
 {
 
-/// Create test context with all subsystems ready.
-SharedPtr<Context> CreateCompleteTestContext();
+/// Serialize and deserialize Scene. Should preserve functional state of nodes and components.
+void SerializeAndDeserializeScene(Scene* scene);
 
-/// Run frame with given time step.
-void RunFrame(Context* context, float timeStep, float maxTimeStep = M_LARGE_VALUE);
-
-}
-
-/// Convert common types to strings
-/// @{
-namespace Catch
+/// Weak reference to Scene node by name. Useful for tests with serialization when actual objects are recreated.
+struct NodeRef
 {
+    WeakPtr<Scene> scene_;
+    ea::string name_;
 
-#define DEFINE_STRING_MAKER(type, expr) \
-    template<> struct StringMaker<type> \
-    { \
-        static std::string convert(const type& value) \
-        { \
-            return expr; \
-        } \
-    }
+    Node* GetNode() const;
 
-DEFINE_STRING_MAKER(Variant, value.ToString().c_str());
-DEFINE_STRING_MAKER(Vector2, value.ToString().c_str());
-DEFINE_STRING_MAKER(Vector3, value.ToString().c_str());
-DEFINE_STRING_MAKER(Vector4, value.ToString().c_str());
-
-#undef DEFINE_STRING_MAKER
+    Node* operator*() const { return GetNode(); }
+    Node* operator->() const { return GetNode(); }
+    bool operator!() const { return GetNode() == nullptr; }
+    explicit operator bool() const { return !!*this; }
+};
 
 }
-/// @}

--- a/Source/Tests/SceneUtils.h
+++ b/Source/Tests/SceneUtils.h
@@ -32,7 +32,11 @@ namespace Tests
 /// Serialize and deserialize Scene. Should preserve functional state of nodes and components.
 void SerializeAndDeserializeScene(Scene* scene);
 
-/// Weak reference to Scene node by name. Useful for tests with serialization when actual objects are recreated.
+/// Return attribute value as variant.
+Variant GetAttributeValue(const ea::pair<Serializable*, unsigned>& ref);
+
+/// Weak reference to Scene node by name.
+/// Useful for tests with serialization when actual objects are recreated.
 struct NodeRef
 {
     WeakPtr<Scene> scene_;
@@ -43,6 +47,26 @@ struct NodeRef
     Node* operator*() const { return GetNode(); }
     Node* operator->() const { return GetNode(); }
     bool operator!() const { return GetNode() == nullptr; }
+    explicit operator bool() const { return !!*this; }
+};
+
+/// Weak reference to Scene component by node name and component type.
+/// Useful for tests with serialization when actual objects are recreated.
+template <class T>
+struct ComponentRef
+{
+    WeakPtr<Scene> scene_;
+    ea::string name_;
+
+    T* GetComponent() const
+    {
+        Node* node = scene_ ? scene_->GetChild(name_, true) : nullptr;
+        return node ? node->GetComponent<T>() : nullptr;
+    }
+
+    T* operator*() const { return GetComponent(); }
+    T* operator->() const { return GetComponent(); }
+    bool operator!() const { return GetComponent() == nullptr; }
     explicit operator bool() const { return !!*this; }
 };
 

--- a/Source/Urho3D/CSharp/Swig/generated/Urho3D/_pre_graphics.i
+++ b/Source/Urho3D/CSharp/Swig/generated/Urho3D/_pre_graphics.i
@@ -792,7 +792,7 @@ using AnimationChannelFlags = Urho3D::AnimationChannel;
 %csattribute(Urho3D::AnimationState, %arg(Urho3D::Animation *), Animation, GetAnimation);
 %csattribute(Urho3D::AnimationState, %arg(Urho3D::AnimatedModel *), Model, GetModel);
 %csattribute(Urho3D::AnimationState, %arg(Urho3D::Node *), Node, GetNode);
-%csattribute(Urho3D::AnimationState, %arg(Urho3D::Bone *), StartBone, GetStartBone, SetStartBone);
+%csattribute(Urho3D::AnimationState, %arg(ea::string), StartBone, GetStartBone, SetStartBone);
 %csattribute(Urho3D::AnimationState, %arg(bool), IsEnabled, IsEnabled);
 %csattribute(Urho3D::AnimationState, %arg(bool), IsLooped, IsLooped, SetLooped);
 %csattribute(Urho3D::AnimationState, %arg(float), Weight, GetWeight, SetWeight);

--- a/Source/Urho3D/Container/KeyFrameSet.h
+++ b/Source/Urho3D/Container/KeyFrameSet.h
@@ -1,0 +1,123 @@
+//
+// Copyright (c) 2017-2020 the rbfx project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+#include "../Core/Variant.h"
+
+#include <EASTL/vector.h>
+#include <EASTL/sort.h>
+
+namespace Urho3D
+{
+
+/// Sorted array of keyframes.
+/// T: must be structure with member `float time_` which is used for ordering.
+template <class T>
+struct KeyFrameSet
+{
+    using KeyFrame = T;
+
+    /// Sort keyframes by time.
+    void SortKeyFrames()
+    {
+        static const auto compare = [](const KeyFrame& lhs, const KeyFrame& rhs) { return lhs.time_ < rhs.time_; };
+        ea::sort(keyFrames_.begin(), keyFrames_.end(), compare);
+    }
+
+    /// Append keyframe preserving container order.
+    void AddKeyFrame(const KeyFrame& keyFrame)
+    {
+        const bool needSort = keyFrames_.size() > 0 && keyFrames_.back().time_ > keyFrame.time_;
+        keyFrames_.push_back(keyFrame);
+        if (needSort)
+            SortKeyFrames();
+    }
+
+    /// Remove a keyframe at index.
+    void RemoveKeyFrame(unsigned index) { keyFrames_.erase_at(index); }
+
+    /// Remove all keyframes.
+    void RemoveAllKeyFrames() { keyFrames_.clear(); }
+
+    /// Return keyframe at index, or null if not found.
+    KeyFrame* GetKeyFrame(unsigned index) { return index < keyFrames_.size() ? &keyFrames_[index] : nullptr; }
+
+    /// Return number of keyframes.
+    /// @property
+    unsigned GetNumKeyFrames() const { return keyFrames_.size(); }
+
+    /// Return keyframes for interpolation.
+    void GetKeyFrames(float time, float duration, bool isLooped,
+        unsigned& frameIndex, unsigned& nextFrameIndex, float& blendFactor) const
+    {
+        GetKeyFrameIndex(time, frameIndex);
+
+        const unsigned numFrames = keyFrames_.size();
+        nextFrameIndex = isLooped
+            ? (frameIndex + 1) % numFrames  // Wrap around if looped
+            : ea::min(frameIndex + 1, numFrames - 1);  // Trim if not looped
+
+        if (frameIndex != nextFrameIndex)
+        {
+            const float frameTime = keyFrames_[frameIndex].time_;
+            const float nextFrameTime = keyFrames_[nextFrameIndex].time_;
+
+            float timeInterval = nextFrameTime - frameTime;
+            if (timeInterval < 0.0f)
+                timeInterval += duration;
+            blendFactor = timeInterval > 0.0f ? (time - frameTime) / timeInterval : 1.0f;
+        }
+        else
+        {
+            blendFactor = 0.0f;
+        }
+    }
+
+    /// Return keyframe index based on time and previous index as hint. Return false if animation is empty.
+    bool GetKeyFrameIndex(float time, unsigned& index) const
+    {
+        if (keyFrames_.empty())
+            return false;
+
+        if (time < 0.0f)
+            time = 0.0f;
+
+        if (index >= keyFrames_.size())
+            index = keyFrames_.size() - 1;
+
+        // Check for being too far ahead
+        while (index && time < keyFrames_[index].time_)
+            --index;
+
+        // Check for being too far behind
+        while (index < keyFrames_.size() - 1 && time >= keyFrames_[index + 1].time_)
+            ++index;
+
+        return true;
+    }
+
+    ea::vector<KeyFrame> keyFrames_;
+};
+
+
+}

--- a/Source/Urho3D/Core/Variant.cpp
+++ b/Source/Urho3D/Core/Variant.cpp
@@ -1058,6 +1058,75 @@ VariantType Variant::GetTypeFromName(const char* typeName)
     return (VariantType)GetStringListIndex(typeName, typeNames, VAR_NONE);
 }
 
+Variant Variant::Lerp(const Variant& rhs, float t) const
+{
+    switch (type_)
+    {
+    case VAR_FLOAT:
+        return Urho3D::Lerp(GetFloat(), rhs.GetFloat(), t);
+
+    case VAR_DOUBLE:
+        return Urho3D::Lerp(GetDouble(), rhs.GetDouble(), t);
+
+    case VAR_INT:
+        return Urho3D::Lerp(GetInt(), rhs.GetInt(), t);
+
+    case VAR_INT64:
+        return Urho3D::Lerp(GetInt64(), rhs.GetInt64(), t);
+
+    case VAR_VECTOR2:
+        return GetVector2().Lerp(rhs.GetVector2(), t);
+
+    case VAR_VECTOR3:
+        return GetVector3().Lerp(rhs.GetVector3(), t);
+
+    case VAR_VECTOR4:
+        return GetVector4().Lerp(rhs.GetVector4(), t);
+
+    case VAR_QUATERNION:
+        return GetQuaternion().Slerp(rhs.GetQuaternion(), t);
+
+    case VAR_COLOR:
+        return GetColor().Lerp(rhs.GetColor(), t);
+
+    case VAR_INTRECT:
+        {
+            const float s = 1.0f - t;
+            const IntRect& r1 = GetIntRect();
+            const IntRect& r2 = rhs.GetIntRect();
+            return IntRect(
+                static_cast<int>(r1.left_ * s + r2.left_ * t),
+                static_cast<int>(r1.top_ * s + r2.top_ * t),
+                static_cast<int>(r1.right_ * s + r2.right_ * t),
+                static_cast<int>(r1.bottom_ * s + r2.bottom_ * t));
+        }
+
+    case VAR_INTVECTOR2:
+        {
+            const float s = 1.0f - t;
+            const IntVector2& v1 = GetIntVector2();
+            const IntVector2& v2 = rhs.GetIntVector2();
+            return IntVector2(
+                static_cast<int>(v1.x_ * s + v2.x_ * t),
+                static_cast<int>(v1.y_ * s + v2.y_ * t));
+        }
+
+    case VAR_INTVECTOR3:
+        {
+            const float s = 1.0f - t;
+            const IntVector3& v1 = GetIntVector3();
+            const IntVector3& v2 = rhs.GetIntVector3();
+            return IntVector3(
+                static_cast<int>(v1.x_ * s + v2.x_ * t),
+                static_cast<int>(v1.y_ * s + v2.y_ * t),
+                static_cast<int>(v1.z_ * s + v2.z_ * t));
+        }
+
+    default:
+        return *this;
+    }
+}
+
 unsigned Variant::ToHash() const
 {
     switch (GetType())

--- a/Source/Urho3D/Core/Variant.h
+++ b/Source/Urho3D/Core/Variant.h
@@ -1486,6 +1486,9 @@ public:
         return nullptr;
     }
 
+    /// Linear interpolation. Supported for scalars, vectors and some other types.
+    Variant Lerp(const Variant& rhs, float t) const;
+
     /// Hash function for containers.
     unsigned ToHash() const;
 

--- a/Source/Urho3D/Graphics/AnimatedModel.cpp
+++ b/Source/Urho3D/Graphics/AnimatedModel.cpp
@@ -28,6 +28,7 @@
 #include "../Core/Profiler.h"
 #include "../Graphics/AnimatedModel.h"
 #include "../Graphics/Animation.h"
+#include "../Graphics/AnimationController.h"
 #include "../Graphics/AnimationState.h"
 #include "../Graphics/Batch.h"
 #include "../Graphics/Camera.h"
@@ -53,22 +54,6 @@ namespace Urho3D
 
 extern const char* GEOMETRY_CATEGORY;
 
-static const StringVector animationStatesStructureElementNames =
-{
-    "Anim State Count",
-    "   Animation",
-    "   Start Bone",
-    "   Is Looped",
-    "   Weight",
-    "   Time",
-    "   Layer"
-};
-
-static bool CompareAnimationOrder(const SharedPtr<AnimationState>& lhs, const SharedPtr<AnimationState>& rhs)
-{
-    return lhs->GetLayer() < rhs->GetLayer();
-}
-
 static const unsigned MAX_ANIMATION_STATES = 256;
 
 AnimatedModel::AnimatedModel(Context* context) :
@@ -79,7 +64,6 @@ AnimatedModel::AnimatedModel(Context* context) :
     animationLodDistance_(0.0f),
     updateInvisible_(false),
     animationDirty_(false),
-    animationOrderDirty_(false),
     morphsDirty_(false),
     skinningDirty_(true),
     boneBoundingBoxDirty_(true),
@@ -126,9 +110,6 @@ void AnimatedModel::RegisterObject(Context* context)
     URHO3D_COPY_BASE_ATTRIBUTES(Drawable);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Bone Animation Enabled", GetBonesEnabledAttr, SetBonesEnabledAttr, VariantVector,
         Variant::emptyVariantVector, AM_FILE | AM_NOEDIT);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Animation States", GetAnimationStatesAttr, SetAnimationStatesAttr,
-        VariantVector, Variant::emptyVariantVector, AM_FILE)
-        .SetMetadata(AttributeMetadata::P_VECTOR_STRUCT_ELEMENTS, animationStatesStructureElementNames);
     URHO3D_ACCESSOR_ATTRIBUTE("Morphs", GetMorphsAttr, SetMorphsAttr, ea::vector<unsigned char>, Variant::emptyBuffer,
         AM_DEFAULT | AM_NOEDIT);
 }
@@ -275,7 +256,7 @@ void AnimatedModel::Update(const FrameInfo& frame)
         animationLodDistance_ = frame.camera_->GetLodDistance(distance, scale, lodBias_);
     }
 
-    if (animationDirty_ || animationOrderDirty_)
+    if (animationDirty_)
         UpdateAnimation(frame);
     else if (boneBoundingBoxDirty_)
         UpdateBoneBoundingBox();
@@ -470,102 +451,6 @@ void AnimatedModel::SetModel(Model* model, bool createBones)
     MarkNetworkUpdate();
 }
 
-AnimationState* AnimatedModel::AddAnimationState(Animation* animation)
-{
-    if (!isMaster_)
-    {
-        URHO3D_LOGERROR("Can not add animation state to non-master model");
-        return nullptr;
-    }
-
-    if (!animation || !skeleton_.GetNumBones())
-        return nullptr;
-
-    // Check for not adding twice
-    AnimationState* existing = GetAnimationState(animation);
-    if (existing)
-        return existing;
-
-    SharedPtr<AnimationState> newState(new AnimationState(this, animation));
-    animationStates_.push_back(newState);
-    MarkAnimationOrderDirty();
-    return newState;
-}
-
-void AnimatedModel::RemoveAnimationState(Animation* animation)
-{
-    if (animation)
-        RemoveAnimationState(animation->GetNameHash());
-    else
-    {
-        for (auto i = animationStates_.begin(); i != animationStates_.end(); ++i)
-        {
-            AnimationState* state = *i;
-            if (!state->GetAnimation())
-            {
-                animationStates_.erase(i);
-                MarkAnimationDirty();
-                return;
-            }
-        }
-    }
-}
-
-void AnimatedModel::RemoveAnimationState(const ea::string& animationName)
-{
-    RemoveAnimationState(StringHash(animationName));
-}
-
-void AnimatedModel::RemoveAnimationState(StringHash animationNameHash)
-{
-    for (auto i = animationStates_.begin(); i != animationStates_.end(); ++i)
-    {
-        AnimationState* state = *i;
-        Animation* animation = state->GetAnimation();
-        if (animation)
-        {
-            // Check both the animation and the resource name
-            if (animation->GetNameHash() == animationNameHash || animation->GetAnimationNameHash() == animationNameHash)
-            {
-                animationStates_.erase(i);
-                MarkAnimationDirty();
-                return;
-            }
-        }
-    }
-}
-
-void AnimatedModel::RemoveAnimationState(AnimationState* state)
-{
-    for (auto i = animationStates_.begin(); i != animationStates_.end(); ++i)
-    {
-        if (*i == state)
-        {
-            animationStates_.erase(i);
-            MarkAnimationDirty();
-            return;
-        }
-    }
-}
-
-void AnimatedModel::RemoveAnimationState(unsigned index)
-{
-    if (index < animationStates_.size())
-    {
-        animationStates_.erase_at(index);
-        MarkAnimationDirty();
-    }
-}
-
-void AnimatedModel::RemoveAllAnimationStates()
-{
-    if (animationStates_.size())
-    {
-        animationStates_.clear();
-        MarkAnimationDirty();
-    }
-}
-
 void AnimatedModel::SetAnimationLodBias(float bias)
 {
     animationLodBias_ = Max(bias, 0.0f);
@@ -690,43 +575,6 @@ float AnimatedModel::GetMorphWeight(StringHash nameHash) const
     return 0.0f;
 }
 
-AnimationState* AnimatedModel::GetAnimationState(Animation* animation) const
-{
-    for (auto i = animationStates_.begin(); i != animationStates_.end(); ++i)
-    {
-        if ((*i)->GetAnimation() == animation)
-            return *i;
-    }
-
-    return nullptr;
-}
-
-AnimationState* AnimatedModel::GetAnimationState(const ea::string& animationName) const
-{
-    return GetAnimationState(StringHash(animationName));
-}
-
-AnimationState* AnimatedModel::GetAnimationState(StringHash animationNameHash) const
-{
-    for (auto i = animationStates_.begin(); i != animationStates_.end(); ++i)
-    {
-        Animation* animation = (*i)->GetAnimation();
-        if (animation)
-        {
-            // Check both the animation and the resource name
-            if (animation->GetNameHash() == animationNameHash || animation->GetAnimationNameHash() == animationNameHash)
-                return *i;
-        }
-    }
-
-    return nullptr;
-}
-
-AnimationState* AnimatedModel::GetAnimationState(unsigned index) const
-{
-    return index < animationStates_.size() ? animationStates_[index] : nullptr;
-}
-
 void AnimatedModel::SetSkeleton(const Skeleton& skeleton, bool createBones)
 {
     if (!node_ && createBones)
@@ -766,7 +614,9 @@ void AnimatedModel::SetSkeleton(const Skeleton& skeleton, bool createBones)
                 return;
         }
 
-        RemoveAllAnimationStates();
+        // Notify animation controller about model change so it can reconnect tracks
+        if (animationController_)
+            animationController_->MarkAnimationStateTracksDirty();
 
         // Detach the rootbone of the previous model if any
         if (createBones)
@@ -846,49 +696,6 @@ void AnimatedModel::SetBonesEnabledAttr(const VariantVector& value)
         bones[i].animated_ = value[i].GetBool();
 }
 
-void AnimatedModel::SetAnimationStatesAttr(const VariantVector& value)
-{
-    auto* cache = GetSubsystem<ResourceCache>();
-    RemoveAllAnimationStates();
-    unsigned index = 0;
-    unsigned numStates = index < value.size() ? value[index++].GetUInt() : 0;
-    // Prevent negative or overly large value being assigned from the editor
-    if (numStates > M_MAX_INT)
-        numStates = 0;
-    if (numStates > MAX_ANIMATION_STATES)
-        numStates = MAX_ANIMATION_STATES;
-
-    animationStates_.reserve(numStates);
-    while (numStates--)
-    {
-        if (index + 5 < value.size())
-        {
-            // Note: null animation is allowed here for editing
-            const ResourceRef& animRef = value[index++].GetResourceRef();
-            SharedPtr<AnimationState> newState(new AnimationState(this, cache->GetResource<Animation>(animRef.name_)));
-            animationStates_.push_back(newState);
-
-            newState->SetStartBone(skeleton_.GetBone(value[index++].GetString()));
-            newState->SetLooped(value[index++].GetBool());
-            newState->SetWeight(value[index++].GetFloat());
-            newState->SetTime(value[index++].GetFloat());
-            newState->SetLayer((unsigned char)value[index++].GetInt());
-        }
-        else
-        {
-            // If not enough data, just add an empty animation state
-            SharedPtr<AnimationState> newState(new AnimationState(this, nullptr));
-            animationStates_.push_back(newState);
-        }
-    }
-
-    if (animationStates_.size())
-    {
-        MarkAnimationDirty();
-        MarkAnimationOrderDirty();
-    }
-}
-
 void AnimatedModel::SetMorphsAttr(const ea::vector<unsigned char>& value)
 {
     for (unsigned index = 0; index < value.size(); ++index)
@@ -907,26 +714,6 @@ VariantVector AnimatedModel::GetBonesEnabledAttr() const
     ret.reserve(bones.size());
     for (auto i = bones.begin(); i != bones.end(); ++i)
         ret.push_back(i->animated_);
-    return ret;
-}
-
-VariantVector AnimatedModel::GetAnimationStatesAttr() const
-{
-    VariantVector ret;
-    ret.reserve(animationStates_.size() * 6 + 1);
-    ret.push_back((int)animationStates_.size());
-    for (auto i = animationStates_.begin(); i != animationStates_.end(); ++i)
-    {
-        AnimationState* state = *i;
-        Animation* animation = state->GetAnimation();
-        Bone* startBone = state->GetStartBone();
-        ret.push_back(GetResourceRef(animation, Animation::GetTypeStatic()));
-        ret.push_back(startBone ? startBone->name_ : EMPTY_STRING);
-        ret.push_back(state->IsLooped());
-        ret.push_back(state->GetWeight());
-        ret.push_back(state->GetTime());
-        ret.push_back((int) state->GetLayer());
-    }
     return ret;
 }
 
@@ -1038,12 +825,9 @@ void AnimatedModel::AssignBoneNodes()
     if (!boneFound && model_)
         SetSkeleton(model_->GetSkeleton(), true);
 
-    // Re-assign the same start bone to animations to get the proper bone node this time
-    for (auto i = animationStates_.begin(); i != animationStates_.end(); ++i)
-    {
-        AnimationState* state = *i;
-        state->SetStartBone(state->GetStartBone());
-    }
+    // Notify AnimationController so it can reconnect to new bone nodes
+    if (animationController_)
+        animationController_->MarkAnimationStateTracksDirty();
 }
 
 void AnimatedModel::FinalizeBoneBoundingBoxes()
@@ -1120,15 +904,6 @@ void AnimatedModel::MarkAnimationDirty()
     if (isMaster_)
     {
         animationDirty_ = true;
-        MarkForUpdate();
-    }
-}
-
-void AnimatedModel::MarkAnimationOrderDirty()
-{
-    if (isMaster_)
-    {
-        animationOrderDirty_ = true;
         MarkForUpdate();
     }
 }
@@ -1210,21 +985,18 @@ void AnimatedModel::UpdateAnimation(const FrameInfo& frame)
 
 void AnimatedModel::ApplyAnimation()
 {
-    // Make sure animations are in ascending priority order
-    if (animationOrderDirty_)
-    {
-        ea::quick_sort(animationStates_.begin(), animationStates_.end(), CompareAnimationOrder);
-        animationOrderDirty_ = false;
-    }
-
     // Reset skeleton, apply all animations, calculate bones' bounding box. Make sure this is only done for the master model
     // (first AnimatedModel in a node)
     if (isMaster_)
     {
         skeleton_.ResetSilent();
-        for (auto i = animationStates_.begin(); i !=
-            animationStates_.end(); ++i)
-            (*i)->Apply();
+
+        // AnimationController is a weak pointer which may or may not be an issue
+        if (AnimationController* animationController = animationController_)
+        {
+            for (AnimationState* state : animationController->GetAnimationStates())
+                state->ApplyModelTracks();
+        }
 
         // Skeleton reset and animations apply the node transforms "silently" to avoid repeated marking dirty. Mark dirty now
         node_->MarkDirty();
@@ -1234,6 +1006,11 @@ void AnimatedModel::ApplyAnimation()
     }
 
     animationDirty_ = false;
+}
+
+void AnimatedModel::ConnectToAnimationController(AnimationController* controller)
+{
+    animationController_ = controller;
 }
 
 void AnimatedModel::UpdateSkinning()

--- a/Source/Urho3D/Graphics/AnimatedModel.h
+++ b/Source/Urho3D/Graphics/AnimatedModel.h
@@ -30,6 +30,7 @@ namespace Urho3D
 {
 
 class Animation;
+class AnimationController;
 class AnimationState;
 class SoftwareModelAnimator;
 
@@ -77,20 +78,6 @@ public:
 
     /// Set model.
     void SetModel(Model* model, bool createBones = true);
-    /// Add an animation.
-    AnimationState* AddAnimationState(Animation* animation);
-    /// Remove an animation by animation pointer.
-    void RemoveAnimationState(Animation* animation);
-    /// Remove an animation by animation name.
-    void RemoveAnimationState(const ea::string& animationName);
-    /// Remove an animation by animation name hash.
-    void RemoveAnimationState(StringHash animationNameHash);
-    /// Remove an animation by AnimationState pointer.
-    void RemoveAnimationState(AnimationState* state);
-    /// Remove an animation by index.
-    void RemoveAnimationState(unsigned index);
-    /// Remove all animations.
-    void RemoveAllAnimationStates();
     /// Set animation LOD bias.
     /// @property
     void SetAnimationLodBias(float bias);
@@ -108,27 +95,12 @@ public:
     void ResetMorphWeights();
     /// Apply all animation states to nodes.
     void ApplyAnimation();
+    /// Connect to AnimationController that provides animation data.
+    void ConnectToAnimationController(AnimationController* controller);
 
     /// Return skeleton.
     /// @property
     Skeleton& GetSkeleton() { return skeleton_; }
-
-    /// Return all animation states.
-    const ea::vector<SharedPtr<AnimationState> >& GetAnimationStates() const { return animationStates_; }
-
-    /// Return number of animation states.
-    /// @property
-    unsigned GetNumAnimationStates() const { return animationStates_.size(); }
-
-    /// Return animation state by animation pointer.
-    AnimationState* GetAnimationState(Animation* animation) const;
-    /// Return animation state by animation name.
-    /// @property{get_animationStates}
-    AnimationState* GetAnimationState(const ea::string& animationName) const;
-    /// Return animation state by animation name hash.
-    AnimationState* GetAnimationState(StringHash animationNameHash) const;
-    /// Return animation state by index.
-    AnimationState* GetAnimationState(unsigned index) const;
 
     /// Return animation LOD bias.
     /// @property
@@ -163,16 +135,12 @@ public:
     void SetModelAttr(const ResourceRef& value);
     /// Set bones' animation enabled attribute.
     void SetBonesEnabledAttr(const VariantVector& value);
-    /// Set animation states attribute.
-    void SetAnimationStatesAttr(const VariantVector& value);
     /// Set morphs attribute.
     void SetMorphsAttr(const ea::vector<unsigned char>& value);
     /// Return model attribute.
     ResourceRef GetModelAttr() const;
     /// Return bones' animation enabled attribute.
     VariantVector GetBonesEnabledAttr() const;
-    /// Return animation states attribute.
-    VariantVector GetAnimationStatesAttr() const;
     /// Return morphs attribute.
     const ea::vector<unsigned char>& GetMorphsAttr() const;
 
@@ -202,8 +170,6 @@ private:
     void RemoveRootBone();
     /// Mark animation and skinning to require an update.
     void MarkAnimationDirty();
-    /// Mark animation and skinning to require a forced update (blending order changed).
-    void MarkAnimationOrderDirty();
     /// Mark morphs to require an update.
     void MarkMorphsDirty();
     /// Set skeleton.
@@ -223,12 +189,12 @@ private:
 
     /// Skeleton.
     Skeleton skeleton_;
+    /// Controller that provides animation states for the model.
+    WeakPtr<AnimationController> animationController_;
     /// Software model animator.
     SharedPtr<SoftwareModelAnimator> modelAnimator_;
     /// Vertex morphs.
     ea::vector<ModelMorph> morphs_;
-    /// Animation states.
-    ea::vector<SharedPtr<AnimationState> > animationStates_;
     /// Skinning matrices.
     ea::vector<Matrix3x4> skinMatrices_;
     /// Mapping of subgeometry bone indices, used if more bones than skinning shader can manage.
@@ -253,8 +219,6 @@ private:
     bool updateInvisible_;
     /// Animation dirty flag.
     bool animationDirty_;
-    /// Animation order dirty flag.
-    bool animationOrderDirty_;
     /// Vertex morphs dirty flag.
     bool morphsDirty_;
     /// Skinning dirty flag.

--- a/Source/Urho3D/Graphics/AnimationController.cpp
+++ b/Source/Urho3D/Graphics/AnimationController.cpp
@@ -35,10 +35,22 @@
 #include "../Scene/Scene.h"
 #include "../Scene/SceneEvents.h"
 
+#include <EASTL/sort.h>
+
 #include "../DebugNew.h"
 
 namespace Urho3D
 {
+
+namespace
+{
+
+bool CompareLayers(const SharedPtr<AnimationState>& lhs, const SharedPtr<AnimationState>& rhs)
+{
+    return lhs->GetLayer() < rhs->GetLayer();
+}
+
+}
 
 static const unsigned char CTRL_LOOPED = 0x1;
 static const unsigned char CTRL_STARTBONE = 0x2;
@@ -70,7 +82,14 @@ void AnimationController::RegisterObject(Context* context)
     URHO3D_ACCESSOR_ATTRIBUTE("Network Animations", GetNetAnimationsAttr, SetNetAnimationsAttr, ea::vector<unsigned char>,
         Variant::emptyBuffer, AM_NET | AM_LATESTDATA | AM_NOEDIT);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Node Animation States", GetNodeAnimationStatesAttr, SetNodeAnimationStatesAttr, VariantVector,
+        Variant::emptyVariantVector, AM_FILE | AM_NOEDIT | AM_READONLY);
+    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Animation States", GetAnimationStatesAttr, SetAnimationStatesAttr, VariantVector,
         Variant::emptyVariantVector, AM_FILE | AM_NOEDIT);
+}
+
+void AnimationController::ApplyAttributes()
+{
+    ConnectToAnimatedModel();
 }
 
 void AnimationController::OnSetEnabled()
@@ -151,9 +170,23 @@ void AnimationController::Update(float timeStep)
             ++i;
     }
 
+    // Sort animation states if necessary
+    if (animationStateOrderDirty_)
+    {
+        ea::sort(animationStates_.begin(), animationStates_.end(), CompareLayers);
+        animationStateOrderDirty_ = false;
+    }
+
+    // Update animation tracks if necessary
+    for (AnimationState* state : animationStates_)
+    {
+        if (state->AreTracksDirty())
+            UpdateAnimationStateTracks(state);
+    }
+
     // Node hierarchy animations need to be applied manually
-    for (auto i = nodeAnimationStates_.begin(); i != nodeAnimationStates_.end(); ++i)
-        (*i)->Apply();
+    for (AnimationState* state : animationStates_)
+        state->ApplyNodeTracks();
 }
 
 bool AnimationController::Play(const ea::string& name, unsigned char layer, bool looped, float fadeInTime)
@@ -310,17 +343,11 @@ bool AnimationController::SetLayer(const ea::string& name, unsigned char layer)
 
 bool AnimationController::SetStartBone(const ea::string& name, const ea::string& startBoneName)
 {
-    // Start bone can only be set in model mode
-    auto* model = GetComponent<AnimatedModel>();
-    if (!model)
-        return false;
-
-    AnimationState* state = model->GetAnimationState(name);
+    AnimationState* state = GetAnimationState(name);
     if (!state)
         return false;
 
-    Bone* bone = model->GetSkeleton().GetBone(startBoneName);
-    state->SetStartBone(bone);
+    state->SetStartBone(startBoneName);
     MarkNetworkUpdate();
     return true;
 }
@@ -486,18 +513,6 @@ unsigned char AnimationController::GetLayer(const ea::string& name) const
     return (unsigned char)(state ? state->GetLayer() : 0);
 }
 
-Bone* AnimationController::GetStartBone(const ea::string& name) const
-{
-    AnimationState* state = GetAnimationState(name);
-    return state ? state->GetStartBone() : nullptr;
-}
-
-const ea::string& AnimationController::GetStartBoneName(const ea::string& name) const
-{
-    Bone* bone = GetStartBone(name);
-    return bone ? bone->name_ : EMPTY_STRING;
-}
-
 float AnimationController::GetTime(const ea::string& name) const
 {
     AnimationState* state = GetAnimationState(name);
@@ -575,13 +590,7 @@ AnimationState* AnimationController::GetAnimationState(const ea::string& name) c
 
 AnimationState* AnimationController::GetAnimationState(StringHash nameHash) const
 {
-    // Model mode
-    auto* model = GetComponent<AnimatedModel>();
-    if (model)
-        return model->GetAnimationState(nameHash);
-
-    // Node hierarchy mode
-    for (auto i = nodeAnimationStates_.begin(); i != nodeAnimationStates_.end(); ++i)
+    for (auto i = animationStates_.begin(); i != animationStates_.end(); ++i)
     {
         Animation* animation = (*i)->GetAnimation();
         if (animation->GetNameHash() == nameHash || animation->GetAnimationNameHash() == nameHash)
@@ -661,12 +670,11 @@ void AnimationController::SetNetAnimationsAttr(const ea::vector<unsigned char>& 
         animations_[index].fadeTime_ = (float)buf.ReadUByte() / 64.0f; // 6 bits of decimal precision, max. 4 seconds fade
         if (ctrl & CTRL_STARTBONE)
         {
-            StringHash boneHash = buf.ReadStringHash();
-            if (model)
-                state->SetStartBone(model->GetSkeleton().GetBone(boneHash));
+            const ea::string startBoneName = buf.ReadString();
+            state->SetStartBone(startBoneName);
         }
         else
-            state->SetStartBone(nullptr);
+            state->SetStartBone("");
         if (ctrl & CTRL_AUTOFADE)
             animations_[index].autoFadeTime_ = (float)buf.ReadUByte() / 64.0f; // 6 bits of decimal precision, max. 4 seconds fade
         else
@@ -712,7 +720,7 @@ void AnimationController::SetNetAnimationsAttr(const ea::vector<unsigned char>& 
 void AnimationController::SetNodeAnimationStatesAttr(const VariantVector& value)
 {
     auto* cache = GetSubsystem<ResourceCache>();
-    nodeAnimationStates_.clear();
+    animationStates_.clear();
     unsigned index = 0;
     unsigned numStates = index < value.size() ? value[index++].GetUInt() : 0;
     // Prevent negative or overly large value being assigned from the editor
@@ -721,15 +729,15 @@ void AnimationController::SetNodeAnimationStatesAttr(const VariantVector& value)
     if (numStates > MAX_NODE_ANIMATION_STATES)
         numStates = MAX_NODE_ANIMATION_STATES;
 
-    nodeAnimationStates_.reserve(numStates);
+    animationStates_.reserve(numStates);
     while (numStates--)
     {
         if (index + 2 < value.size())
         {
             // Note: null animation is allowed here for editing
             const ResourceRef& animRef = value[index++].GetResourceRef();
-            SharedPtr<AnimationState> newState(new AnimationState(GetNode(), cache->GetResource<Animation>(animRef.name_)));
-            nodeAnimationStates_.push_back(newState);
+            SharedPtr<AnimationState> newState(new AnimationState(this, GetNode(), cache->GetResource<Animation>(animRef.name_)));
+            animationStates_.push_back(newState);
 
             newState->SetLooped(value[index++].GetBool());
             newState->SetTime(value[index++].GetFloat());
@@ -737,10 +745,13 @@ void AnimationController::SetNodeAnimationStatesAttr(const VariantVector& value)
         else
         {
             // If not enough data, just add an empty animation state
-            SharedPtr<AnimationState> newState(new AnimationState(GetNode(), nullptr));
-            nodeAnimationStates_.push_back(newState);
+            SharedPtr<AnimationState> newState(new AnimationState(this, GetNode(), nullptr));
+            animationStates_.push_back(newState);
         }
     }
+
+    MarkAnimationStateOrderDirty();
+    MarkAnimationStateTracksDirty();
 }
 
 VariantVector AnimationController::GetAnimationsAttr() const
@@ -779,12 +790,11 @@ const ea::vector<unsigned char>& AnimationController::GetNetAnimationsAttr() con
             continue;
 
         unsigned char ctrl = 0;
-        Bone* startBone = state->GetStartBone();
         if (state->IsLooped())
             ctrl |= CTRL_LOOPED;
         if (state->GetBlendMode() == ABM_ADDITIVE)
             ctrl |= CTRL_ADDITIVE;
-        if (startBone && model && startBone != model->GetSkeleton().GetRootBone())
+        if (!state->GetStartBone().empty())
             ctrl |= CTRL_STARTBONE;
         if (i->autoFadeTime_ > 0.0f)
             ctrl |= CTRL_AUTOFADE;
@@ -802,7 +812,7 @@ const ea::vector<unsigned char>& AnimationController::GetNetAnimationsAttr() con
         attrBuffer_.WriteUByte((unsigned char)(i->targetWeight_ * 255.0f));
         attrBuffer_.WriteUByte((unsigned char)Clamp(i->fadeTime_ * 64.0f, 0.0f, 255.0f));
         if (ctrl & CTRL_STARTBONE)
-            attrBuffer_.WriteStringHash(startBone->nameHash_);
+            attrBuffer_.WriteString(state->GetStartBone());
         if (ctrl & CTRL_AUTOFADE)
             attrBuffer_.WriteUByte((unsigned char)Clamp(i->autoFadeTime_ * 64.0f, 0.0f, 255.0f));
         if (ctrl & CTRL_SETTIME)
@@ -822,18 +832,66 @@ const ea::vector<unsigned char>& AnimationController::GetNetAnimationsAttr() con
 
 VariantVector AnimationController::GetNodeAnimationStatesAttr() const
 {
-    VariantVector ret;
-    ret.reserve(nodeAnimationStates_.size() * 3 + 1);
-    ret.push_back((int)nodeAnimationStates_.size());
-    for (auto i = nodeAnimationStates_.begin(); i != nodeAnimationStates_.end(); ++i)
+    URHO3D_LOGERROR("AnimationController::GetNodeAnimationStatesAttr is deprecated");
+    return Variant::emptyVariantVector;
+}
+
+void AnimationController::SetAnimationStatesAttr(const VariantVector& value)
+{
+    auto* cache = GetSubsystem<ResourceCache>();
+    auto* model = GetComponent<AnimatedModel>();
+
+    animationStates_.clear();
+    animationStates_.reserve(value.size() / 7);
+    unsigned index = 0;
+    while (index + 6 < value.size())
     {
-        AnimationState* state = *i;
+        const ResourceRef& animRef = value[index++].GetResourceRef();
+        const ea::string& startBoneName = value[index++].GetString();
+        const bool isLooped = value[index++].GetBool();
+        const float weight = value[index++].GetFloat();
+        const float time = value[index++].GetFloat();
+        const auto layer = static_cast<unsigned char>(value[index++].GetInt());
+        const auto blendMode = static_cast<AnimationBlendMode>(value[index++].GetInt());
+
+        // Create new animation state
+        const auto animation = cache->GetResource<Animation>(animRef.name_);
+        AnimationState* newState = AddAnimationState(animation);
+
+        // Setup new animation state
+        newState->SetStartBone(startBoneName);
+        newState->SetLooped(isLooped);
+        newState->SetWeight(weight);
+        newState->SetTime(time);
+        newState->SetLayer(layer);
+        newState->SetBlendMode(blendMode);
+    }
+
+    MarkAnimationStateOrderDirty();
+    MarkAnimationStateTracksDirty();
+}
+
+VariantVector AnimationController::GetAnimationStatesAttr() const
+{
+    VariantVector ret;
+    ret.reserve(animationStates_.size() * 7);
+    for (AnimationState* state : animationStates_)
+    {
         Animation* animation = state->GetAnimation();
         ret.push_back(GetResourceRef(animation, Animation::GetTypeStatic()));
+        ret.push_back(state->GetStartBone());
         ret.push_back(state->IsLooped());
+        ret.push_back(state->GetWeight());
         ret.push_back(state->GetTime());
+        ret.push_back((int) state->GetLayer());
+        ret.push_back((int) state->GetBlendMode());
     }
     return ret;
+}
+
+void AnimationController::OnNodeSet(Node* node)
+{
+    ConnectToAnimatedModel();
 }
 
 void AnimationController::OnSceneSet(Scene* scene)
@@ -849,15 +907,14 @@ AnimationState* AnimationController::AddAnimationState(Animation* animation)
     if (!animation)
         return nullptr;
 
-    // Model mode
     auto* model = GetComponent<AnimatedModel>();
     if (model)
-        return model->AddAnimationState(animation);
+        animationStates_.emplace_back(new AnimationState(this, model, animation));
+    else
+        animationStates_.emplace_back(new AnimationState(this, node_, animation));
 
-    // Node hierarchy mode
-    SharedPtr<AnimationState> newState(new AnimationState(node_, animation));
-    nodeAnimationStates_.push_back(newState);
-    return newState;
+    MarkAnimationStateOrderDirty();
+    return animationStates_.back();
 }
 
 void AnimationController::RemoveAnimationState(AnimationState* state)
@@ -865,23 +922,9 @@ void AnimationController::RemoveAnimationState(AnimationState* state)
     if (!state)
         return;
 
-    // Model mode
-    auto* model = GetComponent<AnimatedModel>();
-    if (model)
-    {
-        model->RemoveAnimationState(state);
-        return;
-    }
-
-    // Node hierarchy mode
-    for (auto i = nodeAnimationStates_.begin(); i != nodeAnimationStates_.end(); ++i)
-    {
-        if ((*i) == state)
-        {
-            nodeAnimationStates_.erase(i);
-            return;
-        }
-    }
+    const auto iter = ea::find(animationStates_.begin(), animationStates_.end(), state);
+    if (iter != animationStates_.end())
+        animationStates_.erase(iter);
 }
 
 void AnimationController::FindAnimation(const ea::string& name, unsigned& index, AnimationState*& state) const
@@ -913,6 +956,65 @@ void AnimationController::HandleScenePostUpdate(StringHash eventType, VariantMap
     using namespace ScenePostUpdate;
 
     Update(eventData[P_TIMESTEP].GetFloat());
+}
+
+void AnimationController::MarkAnimationStateTracksDirty()
+{
+    for (AnimationState* state : animationStates_)
+        state->MarkTracksDirty();
+}
+
+void AnimationController::UpdateAnimationStateTracks(AnimationState* state)
+{
+    // TODO(animation): Cache lookups?
+    auto model = GetComponent<AnimatedModel>();
+    const Animation* animation = state->GetAnimation();
+
+    // Reset internal state. Shouldn't cause any reallocations due to simple vectors inside.
+    state->ClearAllTracks();
+
+    // Use root node or start bone node if specified
+    const ea::string& startBoneName = state->GetStartBone();
+    Node* startNode = !startBoneName.empty() ? node_->GetChild(startBoneName, true) : nullptr;
+    if (!startNode)
+        startNode = node_;
+
+    // Setup model and node tracks
+    const auto& tracks = animation->GetTracks();
+    for (const auto& item : tracks)
+    {
+        const AnimationTrack& track = item.second;
+        Node* trackNode = track.nameHash_ == startNode->GetNameHash() ? startNode
+            : startNode->GetChild(track.nameHash_, true);
+        Bone* trackBone = model ? model->GetSkeleton().GetBone(track.nameHash_) : nullptr;
+
+        // Add model track
+        if (trackBone && trackBone->node_)
+        {
+            ModelAnimationStateTrack stateTrack;
+            stateTrack.track_ = &track;
+            stateTrack.node_ = trackNode;
+            stateTrack.bone_ = trackBone;
+            state->AddModelTrack(stateTrack);
+        }
+        else if (trackNode)
+        {
+            NodeAnimationStateTrack stateTrack;
+            stateTrack.track_ = &track;
+            stateTrack.node_ = trackNode;
+            state->AddNodeTrack(stateTrack);
+        }
+    }
+
+    // Setup generic tracks
+    // TODO(animation): Implement me
+}
+
+void AnimationController::ConnectToAnimatedModel()
+{
+    auto model = GetComponent<AnimatedModel>();
+    if (model)
+        model->ConnectToAnimationController(this);
 }
 
 }

--- a/Source/Urho3D/Graphics/AnimationController.h
+++ b/Source/Urho3D/Graphics/AnimationController.h
@@ -232,6 +232,9 @@ private:
     void UpdateAnimationStateTracks(AnimationState* state);
     /// Connect to AnimatedModel if possible.
     void ConnectToAnimatedModel();
+    /// Parse animatable path from starting node.
+    bool ParseAnimatablePath(ea::string_view path, Node* startNode,
+        WeakPtr<Serializable>& serializable, unsigned& attributeIndex, StringHash& variableName);
 
     /// Animation control structures.
     ea::vector<AnimationControl> animations_;

--- a/Source/Urho3D/Graphics/AnimationState.cpp
+++ b/Source/Urho3D/Graphics/AnimationState.cpp
@@ -82,7 +82,7 @@ AnimationState::AnimationState(Node* node, Animation* animation) :
                 AnimationStateTrack stateTrack;
                 stateTrack.track_ = &i->second;
 
-                if (node_->GetNameHash() == nameHash || tracks.size() == 1)
+                if (node_->GetNameHash() == nameHash)
                     stateTrack.node_ = node_;
                 else
                 {

--- a/Source/Urho3D/Graphics/AnimationState.cpp
+++ b/Source/Urho3D/Graphics/AnimationState.cpp
@@ -24,6 +24,7 @@
 
 #include "../Graphics/AnimatedModel.h"
 #include "../Graphics/Animation.h"
+#include "../Graphics/AnimationController.h"
 #include "../Graphics/AnimationState.h"
 #include "../Graphics/DrawableEvents.h"
 #include "../IO/Log.h"
@@ -33,129 +34,53 @@
 namespace Urho3D
 {
 
-AnimationStateTrack::AnimationStateTrack() :
-    track_(nullptr),
-    bone_(nullptr),
-    weight_(1.0f),
-    keyFrame_(0)
-{
-}
-
-AnimationStateTrack::~AnimationStateTrack() = default;
-
-AnimationState::AnimationState(AnimatedModel* model, Animation* animation) :
+AnimationState::AnimationState(AnimationController* controller, AnimatedModel* model, Animation* animation) :
+    controller_(controller),
     model_(model),
-    animation_(animation),
-    startBone_(nullptr),
-    looped_(false),
-    weight_(0.0f),
-    time_(0.0f),
-    layer_(0),
-    blendingMode_(ABM_LERP)
+    animation_(animation)
 {
-    // Set default start bone (use all tracks)
-    SetStartBone(nullptr);
 }
 
-AnimationState::AnimationState(Node* node, Animation* animation) :
+AnimationState::AnimationState(AnimationController* controller, Node* node, Animation* animation) :
+    controller_(controller),
     node_(node),
-    animation_(animation),
-    startBone_(nullptr),
-    looped_(false),
-    weight_(1.0f),
-    time_(0.0f),
-    layer_(0),
-    blendingMode_(ABM_LERP)
+    animation_(animation)
 {
-    if (animation_)
-    {
-        // Setup animation track to scene node mapping
-        if (node_)
-        {
-            const ea::unordered_map<StringHash, AnimationTrack>& tracks = animation_->GetTracks();
-            stateTracks_.clear();
-
-            for (auto i = tracks.begin(); i !=
-                tracks.end(); ++i)
-            {
-                const StringHash& nameHash = i->second.nameHash_;
-                AnimationStateTrack stateTrack;
-                stateTrack.track_ = &i->second;
-
-                if (node_->GetNameHash() == nameHash)
-                    stateTrack.node_ = node_;
-                else
-                {
-                    Node* targetNode = node_->GetChild(nameHash, true);
-                    if (targetNode)
-                        stateTrack.node_ = targetNode;
-                    else
-                        URHO3D_LOGWARNING("Node " + i->second.name_ + " not found for node animation " + animation_->GetName());
-                }
-
-                if (stateTrack.node_)
-                    stateTracks_.push_back(stateTrack);
-            }
-        }
-    }
 }
-
 
 AnimationState::~AnimationState() = default;
 
-void AnimationState::SetStartBone(Bone* startBone)
+bool AnimationState::AreTracksDirty() const
 {
-    if (!model_ || !animation_)
-        return;
+    return tracksDirty_;
+}
 
-    Skeleton& skeleton = model_->GetSkeleton();
-    if (!startBone)
-    {
-        Bone* rootBone = skeleton.GetRootBone();
-        if (!rootBone)
-            return;
-        startBone = rootBone;
-    }
+void AnimationState::MarkTracksDirty()
+{
+    tracksDirty_ = true;
+}
 
-    // Do not reassign if the start bone did not actually change, and we already have valid bone nodes
-    if (startBone == startBone_ && !stateTracks_.empty())
-        return;
+void AnimationState::ClearAllTracks()
+{
+    modelTracks_.clear();
+    nodeTracks_.clear();
+}
 
-    startBone_ = startBone;
+void AnimationState::AddModelTrack(const ModelAnimationStateTrack& track)
+{
+    modelTracks_.push_back(track);
+}
 
-    const ea::unordered_map<StringHash, AnimationTrack>& tracks = animation_->GetTracks();
-    stateTracks_.clear();
+void AnimationState::AddNodeTrack(const NodeAnimationStateTrack& track)
+{
+    nodeTracks_.push_back(track);
+}
 
-    if (!startBone->node_)
-        return;
-
-    for (auto i = tracks.begin(); i != tracks.end(); ++i)
-    {
-        AnimationStateTrack stateTrack;
-        stateTrack.track_ = &i->second;
-
-        // Include those tracks that are either the start bone itself, or its children
-        Bone* trackBone = nullptr;
-        const StringHash& nameHash = i->second.nameHash_;
-
-        if (nameHash == startBone->nameHash_)
-            trackBone = startBone;
-        else
-        {
-            Node* trackBoneNode = startBone->node_->GetChild(nameHash, true);
-            if (trackBoneNode)
-                trackBone = skeleton.GetBone(nameHash);
-        }
-
-        if (trackBone && trackBone->node_)
-        {
-            stateTrack.bone_ = trackBone;
-            stateTrack.node_ = trackBone->node_;
-            stateTracks_.push_back(stateTrack);
-        }
-    }
-
-    model_->MarkAnimationDirty();
+void AnimationState::OnTracksReady()
+{
+    tracksDirty_ = false;
+    if (model_)
+        model_->MarkAnimationDirty();
 }
 
 void AnimationState::SetLooped(bool looped)
@@ -165,27 +90,25 @@ void AnimationState::SetLooped(bool looped)
 
 void AnimationState::SetWeight(float weight)
 {
-    // Weight can only be set in model mode. In node animation it is hardcoded to full
-    if (model_)
+    if (!animation_)
+        return;
+
+    weight = Clamp(weight, 0.0f, 1.0f);
+    if (weight != weight_)
     {
-        weight = Clamp(weight, 0.0f, 1.0f);
-        if (weight != weight_)
-        {
-            weight_ = weight;
+        weight_ = weight;
+        if (model_)
             model_->MarkAnimationDirty();
-        }
     }
 }
 
 void AnimationState::SetBlendMode(AnimationBlendMode mode)
 {
-    if (model_)
+    if (blendingMode_ != mode)
     {
-        if (blendingMode_ != mode)
-        {
-            blendingMode_ = mode;
+        blendingMode_ = mode;
+        if (model_)
             model_->MarkAnimationDirty();
-        }
     }
 }
 
@@ -203,44 +126,18 @@ void AnimationState::SetTime(float time)
     }
 }
 
-void AnimationState::SetBoneWeight(unsigned index, float weight, bool recursive)
+void AnimationState::SetStartBone(const ea::string& name)
 {
-    if (index >= stateTracks_.size())
+    if (!animation_)
         return;
 
-    weight = Clamp(weight, 0.0f, 1.0f);
-
-    if (weight != stateTracks_[index].weight_)
+    if (name != startBone_)
     {
-        stateTracks_[index].weight_ = weight;
+        startBone_ = name;
+        MarkTracksDirty();
         if (model_)
             model_->MarkAnimationDirty();
     }
-
-    if (recursive)
-    {
-        Node* boneNode = stateTracks_[index].node_;
-        if (boneNode)
-        {
-            const ea::vector<SharedPtr<Node> >& children = boneNode->GetChildren();
-            for (unsigned i = 0; i < children.size(); ++i)
-            {
-                unsigned childTrackIndex = GetTrackIndex(children[i]);
-                if (childTrackIndex != M_MAX_UNSIGNED)
-                    SetBoneWeight(childTrackIndex, weight, true);
-            }
-        }
-    }
-}
-
-void AnimationState::SetBoneWeight(const ea::string& name, float weight, bool recursive)
-{
-    SetBoneWeight(GetTrackIndex(name), weight, recursive);
-}
-
-void AnimationState::SetBoneWeight(StringHash nameHash, float weight, bool recursive)
-{
-    SetBoneWeight(GetTrackIndex(nameHash), weight, recursive);
 }
 
 void AnimationState::AddWeight(float delta)
@@ -367,8 +264,7 @@ void AnimationState::SetLayer(unsigned char layer)
     if (layer != layer_)
     {
         layer_ = layer;
-        if (model_)
-            model_->MarkAnimationOrderDirty();
+        controller_->MarkAnimationStateOrderDirty();
     }
 }
 
@@ -382,114 +278,49 @@ Node* AnimationState::GetNode() const
     return node_;
 }
 
-Bone* AnimationState::GetStartBone() const
-{
-    return model_ ? startBone_ : nullptr;
-}
-
-float AnimationState::GetBoneWeight(unsigned index) const
-{
-    return index < stateTracks_.size() ? stateTracks_[index].weight_ : 0.0f;
-}
-
-float AnimationState::GetBoneWeight(const ea::string& name) const
-{
-    return GetBoneWeight(GetTrackIndex(name));
-}
-
-float AnimationState::GetBoneWeight(StringHash nameHash) const
-{
-    return GetBoneWeight(GetTrackIndex(nameHash));
-}
-
-unsigned AnimationState::GetTrackIndex(const ea::string& name) const
-{
-    for (unsigned i = 0; i < stateTracks_.size(); ++i)
-    {
-        Node* node = stateTracks_[i].node_;
-        if (node && node->GetName() == name)
-            return i;
-    }
-
-    return M_MAX_UNSIGNED;
-}
-
-unsigned AnimationState::GetTrackIndex(Node* node) const
-{
-    for (unsigned i = 0; i < stateTracks_.size(); ++i)
-    {
-        if (stateTracks_[i].node_ == node)
-            return i;
-    }
-
-    return M_MAX_UNSIGNED;
-}
-
-unsigned AnimationState::GetTrackIndex(StringHash nameHash) const
-{
-    for (unsigned i = 0; i < stateTracks_.size(); ++i)
-    {
-        Node* node = stateTracks_[i].node_;
-        if (node && node->GetNameHash() == nameHash)
-            return i;
-    }
-
-    return M_MAX_UNSIGNED;
-}
-
 float AnimationState::GetLength() const
 {
     return animation_ ? animation_->GetLength() : 0.0f;
 }
 
-void AnimationState::Apply()
+void AnimationState::ApplyModelTracks()
 {
     if (!animation_ || !IsEnabled())
         return;
 
-    if (model_)
-        ApplyToModel();
-    else
-        ApplyToNodes();
-}
-
-void AnimationState::ApplyToModel()
-{
-    for (auto i = stateTracks_.begin(); i != stateTracks_.end(); ++i)
+    for (ModelAnimationStateTrack& stateTrack : modelTracks_)
     {
-        AnimationStateTrack& stateTrack = *i;
-        float finalWeight = weight_ * stateTrack.weight_;
-
-        // Do not apply if zero effective weight or the bone has animation disabled
-        if (Equals(finalWeight, 0.0f) || !stateTrack.bone_->animated_)
+        // Do not apply if the bone has animation disabled
+        if (!stateTrack.bone_->animated_)
             continue;
 
-        ApplyTrack(stateTrack, finalWeight, true);
+        ApplyTransformTrack(*stateTrack.track_, stateTrack.node_, stateTrack.bone_, stateTrack.keyFrame_, weight_, true);
     }
 }
 
-void AnimationState::ApplyToNodes()
+void AnimationState::ApplyNodeTracks()
 {
-    // When applying to a node hierarchy, can only use full weight (nothing to blend to)
-    for (auto i = stateTracks_.begin(); i != stateTracks_.end(); ++i)
-        ApplyTrack(*i, 1.0f, false);
-}
-
-void AnimationState::ApplyTrack(AnimationStateTrack& stateTrack, float weight, bool silent)
-{
-    const AnimationTrack* track = stateTrack.track_;
-    Node* node = stateTrack.node_;
-
-    if (track->keyFrames_.empty() || !node)
+    if (!animation_ || !IsEnabled())
         return;
 
-    unsigned& frame = stateTrack.keyFrame_;
-    track->GetKeyFrameIndex(time_, frame);
+    for (NodeAnimationStateTrack& stateTrack : nodeTracks_)
+    {
+        ApplyTransformTrack(*stateTrack.track_, stateTrack.node_, nullptr, stateTrack.keyFrame_, weight_, false);
+    }
+}
+
+void AnimationState::ApplyTransformTrack(const AnimationTrack& track,
+    Node* node, Bone* bone, unsigned& frame, float weight, bool silent)
+{
+    if (track.keyFrames_.empty() || !node)
+        return;
+
+    track.GetKeyFrameIndex(time_, frame);
 
     // Check if next frame to interpolate to is valid, or if wrapping is needed (looping animation only)
     unsigned nextFrame = frame + 1;
     bool interpolate = true;
-    if (nextFrame >= track->keyFrames_.size())
+    if (nextFrame >= track.keyFrames_.size())
     {
         if (!looped_)
         {
@@ -500,8 +331,8 @@ void AnimationState::ApplyTrack(AnimationStateTrack& stateTrack, float weight, b
             nextFrame = 0;
     }
 
-    const AnimationKeyFrame* keyFrame = &track->keyFrames_[frame];
-    const AnimationChannelFlags channelMask = track->channelMask_;
+    const AnimationKeyFrame* keyFrame = &track.keyFrames_[frame];
+    const AnimationChannelFlags channelMask = track.channelMask_;
 
     Vector3 newPosition;
     Quaternion newRotation;
@@ -509,7 +340,7 @@ void AnimationState::ApplyTrack(AnimationStateTrack& stateTrack, float weight, b
 
     if (interpolate)
     {
-        const AnimationKeyFrame* nextKeyFrame = &track->keyFrames_[nextFrame];
+        const AnimationKeyFrame* nextKeyFrame = &track.keyFrames_[nextFrame];
         float timeInterval = nextKeyFrame->time_ - keyFrame->time_;
         if (timeInterval < 0.0f)
             timeInterval += animation_->GetLength();
@@ -536,19 +367,19 @@ void AnimationState::ApplyTrack(AnimationStateTrack& stateTrack, float weight, b
     {
         if (channelMask & CHANNEL_POSITION)
         {
-            Vector3 delta = newPosition - stateTrack.bone_->initialPosition_;
+            const Vector3 delta = bone ? (newPosition - bone->initialPosition_) : newPosition;
             newPosition = node->GetPosition() + delta * weight;
         }
         if (channelMask & CHANNEL_ROTATION)
         {
-            Quaternion delta = newRotation * stateTrack.bone_->initialRotation_.Inverse();
+            const Quaternion delta = bone ? (newRotation * bone->initialRotation_.Inverse()) : newRotation;
             newRotation = (delta * node->GetRotation()).Normalized();
             if (!Equals(weight, 1.0f))
                 newRotation = node->GetRotation().Slerp(newRotation, weight);
         }
         if (channelMask & CHANNEL_SCALE)
         {
-            Vector3 delta = newScale - stateTrack.bone_->initialScale_;
+            const Vector3 delta = bone ? (newScale - bone->initialScale_) : newScale;
             newScale = node->GetScale() + delta * weight;
         }
     }

--- a/Source/Urho3D/Graphics/AnimationState.cpp
+++ b/Source/Urho3D/Graphics/AnimationState.cpp
@@ -34,6 +34,53 @@
 namespace Urho3D
 {
 
+namespace
+{
+
+Variant BlendAdditive(const Variant& oldValue, const Variant& newValue, const Variant& baseValue, float weight)
+{
+    switch (newValue.GetType())
+    {
+    case VAR_FLOAT:
+        return oldValue.GetFloat() + (newValue.GetFloat() - baseValue.GetFloat()) * weight;
+
+    case VAR_DOUBLE:
+        return oldValue.GetDouble() + (newValue.GetDouble() - baseValue.GetDouble()) * weight;
+
+    case VAR_INT:
+        return static_cast<int>(oldValue.GetInt() + (newValue.GetInt() - baseValue.GetInt()) * weight);
+
+    case VAR_INT64:
+        return static_cast<long long>(oldValue.GetInt64() + (newValue.GetInt64() - baseValue.GetInt64()) * weight);
+
+    case VAR_VECTOR2:
+        return oldValue.GetVector2() + (newValue.GetVector2() - baseValue.GetVector2()) * weight;
+
+    case VAR_VECTOR3:
+        return oldValue.GetVector3() + (newValue.GetVector3() - baseValue.GetVector3()) * weight;
+
+    case VAR_VECTOR4:
+        return oldValue.GetVector4() + (newValue.GetVector4() - baseValue.GetVector4()) * weight;
+
+    case VAR_QUATERNION:
+        return oldValue.GetQuaternion() * Quaternion::IDENTITY.Slerp(newValue.GetQuaternion() * baseValue.GetQuaternion().Inverse(), weight);
+
+    case VAR_COLOR:
+        return oldValue.GetColor() + (newValue.GetColor() - baseValue.GetColor()) * weight;
+
+    case VAR_INTVECTOR2:
+        return oldValue.GetIntVector2() + VectorRoundToInt(static_cast<Vector2>(newValue.GetIntVector2() - baseValue.GetIntVector2()) * weight);
+
+    case VAR_INTVECTOR3:
+        return oldValue.GetIntVector3() + VectorRoundToInt(static_cast<Vector3>(newValue.GetIntVector3() - baseValue.GetIntVector3()) * weight);
+
+    default:
+        return oldValue;
+    }
+}
+
+}
+
 AnimationState::AnimationState(AnimationController* controller, AnimatedModel* model, Animation* animation) :
     controller_(controller),
     model_(model),
@@ -64,6 +111,7 @@ void AnimationState::ClearAllTracks()
 {
     modelTracks_.clear();
     nodeTracks_.clear();
+    attributeTracks_.clear();
 }
 
 void AnimationState::AddModelTrack(const ModelAnimationStateTrack& track)
@@ -74,6 +122,11 @@ void AnimationState::AddModelTrack(const ModelAnimationStateTrack& track)
 void AnimationState::AddNodeTrack(const NodeAnimationStateTrack& track)
 {
     nodeTracks_.push_back(track);
+}
+
+void AnimationState::AddAttributeTrack(const AttributeAnimationStateTrack& track)
+{
+    attributeTracks_.push_back(track);
 }
 
 void AnimationState::OnTracksReady()
@@ -309,78 +362,49 @@ void AnimationState::ApplyNodeTracks()
     }
 }
 
+void AnimationState::ApplyAttributeTracks()
+{
+    if (!animation_ || !IsEnabled())
+        return;
+
+    for (AttributeAnimationStateTrack& stateTrack : attributeTracks_)
+    {
+        ApplyAttributeTrack(stateTrack, weight_);
+    }
+}
+
 void AnimationState::ApplyTransformTrack(const AnimationTrack& track,
     Node* node, Bone* bone, unsigned& frame, float weight, bool silent)
 {
     if (track.keyFrames_.empty() || !node)
         return;
 
-    track.GetKeyFrameIndex(time_, frame);
-
-    // Check if next frame to interpolate to is valid, or if wrapping is needed (looping animation only)
-    unsigned nextFrame = frame + 1;
-    bool interpolate = true;
-    if (nextFrame >= track.keyFrames_.size())
-    {
-        if (!looped_)
-        {
-            nextFrame = frame;
-            interpolate = false;
-        }
-        else
-            nextFrame = 0;
-    }
-
-    const AnimationKeyFrame* keyFrame = &track.keyFrames_[frame];
     const AnimationChannelFlags channelMask = track.channelMask_;
 
-    Vector3 newPosition;
-    Quaternion newRotation;
-    Vector3 newScale;
-
-    if (interpolate)
-    {
-        const AnimationKeyFrame* nextKeyFrame = &track.keyFrames_[nextFrame];
-        float timeInterval = nextKeyFrame->time_ - keyFrame->time_;
-        if (timeInterval < 0.0f)
-            timeInterval += animation_->GetLength();
-        float t = timeInterval > 0.0f ? (time_ - keyFrame->time_) / timeInterval : 1.0f;
-
-        if (channelMask & CHANNEL_POSITION)
-            newPosition = keyFrame->position_.Lerp(nextKeyFrame->position_, t);
-        if (channelMask & CHANNEL_ROTATION)
-            newRotation = keyFrame->rotation_.Slerp(nextKeyFrame->rotation_, t);
-        if (channelMask & CHANNEL_SCALE)
-            newScale = keyFrame->scale_.Lerp(nextKeyFrame->scale_, t);
-    }
-    else
-    {
-        if (channelMask & CHANNEL_POSITION)
-            newPosition = keyFrame->position_;
-        if (channelMask & CHANNEL_ROTATION)
-            newRotation = keyFrame->rotation_;
-        if (channelMask & CHANNEL_SCALE)
-            newScale = keyFrame->scale_;
-    }
+    Transform newTransform;
+    track.Sample(time_, animation_->GetLength(), looped_, frame, newTransform);
 
     if (blendingMode_ == ABM_ADDITIVE) // not ABM_LERP
     {
         if (channelMask & CHANNEL_POSITION)
         {
-            const Vector3 delta = bone ? (newPosition - bone->initialPosition_) : newPosition;
-            newPosition = node->GetPosition() + delta * weight;
+            const Vector3& base = bone ? bone->initialPosition_ : track.baseValue_.position_;
+            const Vector3 delta = newTransform.position_ - base;
+            newTransform.position_ = node->GetPosition() + delta * weight;
         }
         if (channelMask & CHANNEL_ROTATION)
         {
-            const Quaternion delta = bone ? (newRotation * bone->initialRotation_.Inverse()) : newRotation;
-            newRotation = (delta * node->GetRotation()).Normalized();
+            const Quaternion& base = bone ? bone->initialRotation_ : track.baseValue_.rotation_;
+            const Quaternion delta = newTransform.rotation_ * base.Inverse();
+            newTransform.rotation_ = (delta * node->GetRotation()).Normalized();
             if (!Equals(weight, 1.0f))
-                newRotation = node->GetRotation().Slerp(newRotation, weight);
+                newTransform.rotation_ = node->GetRotation().Slerp(newTransform.rotation_, weight);
         }
         if (channelMask & CHANNEL_SCALE)
         {
-            const Vector3 delta = bone ? (newScale - bone->initialScale_) : newScale;
-            newScale = node->GetScale() + delta * weight;
+            const Vector3& base = bone ? bone->initialScale_ : track.baseValue_.scale_;
+            const Vector3 delta = newTransform.scale_ - base;
+            newTransform.scale_ = node->GetScale() + delta * weight;
         }
     }
     else
@@ -388,31 +412,70 @@ void AnimationState::ApplyTransformTrack(const AnimationTrack& track,
         if (!Equals(weight, 1.0f)) // not full weight
         {
             if (channelMask & CHANNEL_POSITION)
-                newPosition = node->GetPosition().Lerp(newPosition, weight);
+                newTransform.position_ = node->GetPosition().Lerp(newTransform.position_, weight);
             if (channelMask & CHANNEL_ROTATION)
-                newRotation = node->GetRotation().Slerp(newRotation, weight);
+                newTransform.rotation_ = node->GetRotation().Slerp(newTransform.rotation_, weight);
             if (channelMask & CHANNEL_SCALE)
-                newScale = node->GetScale().Lerp(newScale, weight);
+                newTransform.scale_ = node->GetScale().Lerp(newTransform.scale_, weight);
         }
     }
 
     if (silent)
     {
         if (channelMask & CHANNEL_POSITION)
-            node->SetPositionSilent(newPosition);
+            node->SetPositionSilent(newTransform.position_);
         if (channelMask & CHANNEL_ROTATION)
-            node->SetRotationSilent(newRotation);
+            node->SetRotationSilent(newTransform.rotation_);
         if (channelMask & CHANNEL_SCALE)
-            node->SetScaleSilent(newScale);
+            node->SetScaleSilent(newTransform.scale_);
     }
     else
     {
         if (channelMask & CHANNEL_POSITION)
-            node->SetPosition(newPosition);
+            node->SetPosition(newTransform.position_);
         if (channelMask & CHANNEL_ROTATION)
-            node->SetRotation(newRotation);
+            node->SetRotation(newTransform.rotation_);
         if (channelMask & CHANNEL_SCALE)
-            node->SetScale(newScale);
+            node->SetScale(newTransform.scale_);
+    }
+}
+
+void AnimationState::ApplyAttributeTrack(AttributeAnimationStateTrack& stateTrack, float weight)
+{
+    const VariantAnimationTrack& track = *stateTrack.track_;
+    Serializable* serializable = stateTrack.serializable_;
+    if (track.keyFrames_.empty() || !serializable)
+        return;
+
+    Variant newValue = track.Sample(time_, animation_->GetLength(), looped_, stateTrack.keyFrame_);
+
+    // Apply blending
+    if (blendingMode_ == ABM_ADDITIVE || !Equals(weight, 1.0f))
+    {
+        Variant oldValue;
+        if (stateTrack.variableName_ == StringHash{})
+            oldValue = serializable->GetAttribute(stateTrack.attributeIndex_);
+        else
+        {
+            assert(dynamic_cast<Node*>(serializable));
+            auto node = static_cast<Node*>(serializable);
+            oldValue = node->GetVar(stateTrack.variableName_);
+        }
+
+        if (blendingMode_ == ABM_ADDITIVE)
+            newValue = BlendAdditive(oldValue, newValue, track.baseValue_, weight);
+        else
+            newValue = oldValue.Lerp(newValue, weight);
+    }
+
+    // Apply final value
+    if (stateTrack.variableName_ == StringHash{})
+        serializable->SetAttribute(stateTrack.attributeIndex_, newValue);
+    else
+    {
+        assert(dynamic_cast<Node*>(serializable));
+        auto node = static_cast<Node*>(serializable);
+        node->SetVar(stateTrack.variableName_, newValue);
     }
 }
 

--- a/Source/Urho3D/Graphics/AnimationState.h
+++ b/Source/Urho3D/Graphics/AnimationState.h
@@ -33,6 +33,7 @@ namespace Urho3D
 {
 
 class Animation;
+class AnimationController;
 class AnimatedModel;
 class Deserializer;
 class Node;
@@ -50,36 +51,22 @@ enum AnimationBlendMode
     ABM_ADDITIVE
 };
 
-/// %Animation instance per-track data.
-struct URHO3D_API AnimationStateTrack
+/// Per-track data of skinned model animation.
+/// TODO(animation): Do we want per-bone weights?
+struct URHO3D_API ModelAnimationStateTrack
 {
-    /// Construct with defaults.
-    AnimationStateTrack();
-    /// Destruct.
-    ~AnimationStateTrack();
-
-    /// Instance equality operator.
-    bool operator ==(const AnimationStateTrack& rhs) const
-    {
-        return this == &rhs;
-    }
-
-    /// Instance inequality operator.
-    bool operator !=(const AnimationStateTrack& rhs) const
-    {
-        return this != &rhs;
-    }
-
-    /// Animation track.
-    const AnimationTrack* track_;
-    /// Bone pointer.
-    Bone* bone_;
-    /// Scene node pointer.
+    const AnimationTrack* track_{};
+    Bone* bone_{};
     WeakPtr<Node> node_;
-    /// Blending weight.
-    float weight_;
-    /// Last key frame.
-    unsigned keyFrame_;
+    unsigned keyFrame_{};
+};
+
+/// Per-track data of node model animation.
+struct URHO3D_API NodeAnimationStateTrack
+{
+    const AnimationTrack* track_{};
+    WeakPtr<Node> node_;
+    unsigned keyFrame_{};
 };
 
 /// %Animation instance.
@@ -87,15 +74,22 @@ class URHO3D_API AnimationState : public RefCounted
 {
 public:
     /// Construct with animated model and animation pointers.
-    AnimationState(AnimatedModel* model, Animation* animation);
+    AnimationState(AnimationController* controller, AnimatedModel* model, Animation* animation);
     /// Construct with root scene node and animation pointers.
-    AnimationState(Node* node, Animation* animation);
+    AnimationState(AnimationController* controller, Node* node, Animation* animation);
     /// Destruct.
     ~AnimationState() override;
 
-    /// Set start bone. Not supported in node animation mode. Resets any assigned per-bone weights.
-    /// @property
-    void SetStartBone(Bone* startBone);
+    /// Modify tracks. For internal use only.
+    /// @{
+    bool AreTracksDirty() const;
+    void MarkTracksDirty();
+    void ClearAllTracks();
+    void AddModelTrack(const ModelAnimationStateTrack& track);
+    void AddNodeTrack(const NodeAnimationStateTrack& track);
+    void OnTracksReady();
+    /// @}
+
     /// Set looping enabled/disabled.
     /// @property
     void SetLooped(bool looped);
@@ -108,12 +102,8 @@ public:
     /// Set time position. Does not fire animation triggers.
     /// @property
     void SetTime(float time);
-    /// Set per-bone blending weight by track index. Default is 1.0 (full), is multiplied  with the state's blending weight when applying the animation. Optionally recurses to child bones.
-    void SetBoneWeight(unsigned index, float weight, bool recursive = false);
-    /// Set per-bone blending weight by name.
-    void SetBoneWeight(const ea::string& name, float weight, bool recursive = false);
-    /// Set per-bone blending weight by name hash.
-    void SetBoneWeight(StringHash nameHash, float weight, bool recursive = false);
+    /// Set start bone name.
+    void SetStartBone(const ea::string& name);
     /// Modify blending weight.
     void AddWeight(float delta);
     /// Modify time position. %Animation triggers will be fired.
@@ -132,22 +122,9 @@ public:
     /// Return root scene node this state controls (node hierarchy mode).
     /// @property
     Node* GetNode() const;
-    /// Return start bone.
-    /// @property
-    Bone* GetStartBone() const;
-    /// Return per-bone blending weight by track index.
-    float GetBoneWeight(unsigned index) const;
-    /// Return per-bone blending weight by name.
-    /// @property{get_boneWeights}
-    float GetBoneWeight(const ea::string& name) const;
-    /// Return per-bone blending weight by name.
-    float GetBoneWeight(StringHash nameHash) const;
-    /// Return track index with matching bone node, or M_MAX_UNSIGNED if not found.
-    unsigned GetTrackIndex(Node* node) const;
-    /// Return track index by bone name, or M_MAX_UNSIGNED if not found.
-    unsigned GetTrackIndex(const ea::string& name) const;
-    /// Return track index by bone name hash, or M_MAX_UNSIGNED if not found.
-    unsigned GetTrackIndex(StringHash nameHash) const;
+
+    /// Return name of start bone.
+    const ea::string& GetStartBone() const { return startBone_; }
 
     /// Return whether weight is nonzero.
     /// @property
@@ -177,37 +154,45 @@ public:
     /// @property
     unsigned char GetLayer() const { return layer_; }
 
-    /// Apply the animation at the current time position.
-    void Apply();
+    /// Apply animation to a skeleton. Transform changes are applied silently, so the model needs to dirty its root model afterward.
+    void ApplyModelTracks();
+    /// Apply animation to a scene node hierarchy.
+    void ApplyNodeTracks();
 
 private:
-    /// Apply animation to a skeleton. Transform changes are applied silently, so the model needs to dirty its root model afterward.
-    void ApplyToModel();
-    /// Apply animation to a scene node hierarchy.
-    void ApplyToNodes();
-    /// Apply track.
-    void ApplyTrack(AnimationStateTrack& stateTrack, float weight, bool silent);
+    /// Apply single transformation track to target object. Key frame hint is updated on call.
+    void ApplyTransformTrack(const AnimationTrack& track,
+        Node* node, Bone* bone, unsigned& frame, float weight, bool silent);
 
+    /// Owner controller.
+    WeakPtr<AnimationController> controller_;
     /// Animated model (model mode).
     WeakPtr<AnimatedModel> model_;
     /// Root scene node (node hierarchy mode).
     WeakPtr<Node> node_;
     /// Animation.
     SharedPtr<Animation> animation_;
-    /// Start bone.
-    Bone* startBone_;
-    /// Per-track data.
-    ea::vector<AnimationStateTrack> stateTracks_;
-    /// Looped flag.
-    bool looped_;
-    /// Blending weight.
-    float weight_;
-    /// Time position.
-    float time_;
-    /// Blending layer.
-    unsigned char layer_;
-    /// Blending mode.
-    AnimationBlendMode blendingMode_;
+
+    /// Whether the animation state tracks are dirty and should be updated.
+    bool tracksDirty_{ true };
+
+    /// Dynamic properties of AnimationState.
+    /// @{
+    bool looped_{};
+    float weight_{};
+    float time_{};
+    unsigned char layer_{};
+    AnimationBlendMode blendingMode_{};
+    ea::string startBone_;
+    /// @}
+
+    /// Tracks that are actually applied to the objects.
+    /// @{
+    ea::vector<ModelAnimationStateTrack> modelTracks_;
+    ea::vector<NodeAnimationStateTrack> nodeTracks_;
+    /// @}
 };
+
+using AnimationStateVector = ea::vector<SharedPtr<AnimationState>>;
 
 }

--- a/Source/Urho3D/Graphics/AnimationState.h
+++ b/Source/Urho3D/Graphics/AnimationState.h
@@ -40,6 +40,7 @@ class Node;
 class Serializer;
 class Skeleton;
 struct AnimationTrack;
+struct VariantAnimationTrack;
 struct Bone;
 
 /// %Animation blending mode.
@@ -69,6 +70,16 @@ struct URHO3D_API NodeAnimationStateTrack
     unsigned keyFrame_{};
 };
 
+/// Per-track data of attribute animation.
+struct URHO3D_API AttributeAnimationStateTrack
+{
+    const VariantAnimationTrack* track_{};
+    WeakPtr<Serializable> serializable_;
+    unsigned attributeIndex_{};
+    StringHash variableName_;
+    unsigned keyFrame_{};
+};
+
 /// %Animation instance.
 class URHO3D_API AnimationState : public RefCounted
 {
@@ -87,6 +98,7 @@ public:
     void ClearAllTracks();
     void AddModelTrack(const ModelAnimationStateTrack& track);
     void AddNodeTrack(const NodeAnimationStateTrack& track);
+    void AddAttributeTrack(const AttributeAnimationStateTrack& track);
     void OnTracksReady();
     /// @}
 
@@ -158,11 +170,15 @@ public:
     void ApplyModelTracks();
     /// Apply animation to a scene node hierarchy.
     void ApplyNodeTracks();
+    /// Apply animation to attributes.
+    void ApplyAttributeTracks();
 
 private:
     /// Apply single transformation track to target object. Key frame hint is updated on call.
     void ApplyTransformTrack(const AnimationTrack& track,
         Node* node, Bone* bone, unsigned& frame, float weight, bool silent);
+    /// Apply single attribute track to target object. Key frame hint is updated on call.
+    void ApplyAttributeTrack(AttributeAnimationStateTrack& stateTrack, float weight);
 
     /// Owner controller.
     WeakPtr<AnimationController> controller_;
@@ -190,6 +206,7 @@ private:
     /// @{
     ea::vector<ModelAnimationStateTrack> modelTracks_;
     ea::vector<NodeAnimationStateTrack> nodeTracks_;
+    ea::vector<AttributeAnimationStateTrack> attributeTracks_;
     /// @}
 };
 

--- a/Source/Urho3D/Graphics/AnimationTrack.cpp
+++ b/Source/Urho3D/Graphics/AnimationTrack.cpp
@@ -1,0 +1,223 @@
+//
+// Copyright (c) 2008-2020 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "../Precompiled.h"
+
+#include "../Graphics/AnimationTrack.h"
+
+#include "../DebugNew.h"
+
+namespace Urho3D
+{
+
+namespace
+{
+
+Variant InterpolateSpline(VariantType type,
+    const Variant& v1, const Variant& v2, const Variant& t1, const Variant& t2, float t)
+{
+    const float tt = t * t;
+    const float ttt = t * tt;
+
+    const float h1 = 2.0f * ttt - 3.0f * tt + 1.0f;
+    const float h2 = -2.0f * ttt + 3.0f * tt;
+    const float h3 = ttt - 2.0f * tt + t;
+    const float h4 = ttt - tt;
+
+    switch (type)
+    {
+    case VAR_FLOAT:
+        return v1.GetFloat() * h1 + v2.GetFloat() * h2 + t1.GetFloat() * h3 + t2.GetFloat() * h4;
+
+    case VAR_VECTOR2:
+        return v1.GetVector2() * h1 + v2.GetVector2() * h2 + t1.GetVector2() * h3 + t2.GetVector2() * h4;
+
+    case VAR_VECTOR3:
+        return v1.GetVector3() * h1 + v2.GetVector3() * h2 + t1.GetVector3() * h3 + t2.GetVector3() * h4;
+
+    case VAR_VECTOR4:
+        return v1.GetVector4() * h1 + v2.GetVector4() * h2 + t1.GetVector4() * h3 + t2.GetVector4() * h4;
+
+    case VAR_QUATERNION:
+        return v1.GetQuaternion() * h1 + v2.GetQuaternion() * h2 + t1.GetQuaternion() * h3 + t2.GetQuaternion() * h4;
+
+    case VAR_COLOR:
+        return v1.GetColor() * h1 + v2.GetColor() * h2 + t1.GetColor() * h3 + t2.GetColor() * h4;
+
+    case VAR_DOUBLE:
+        return v1.GetDouble() * h1 + v2.GetDouble() * h2 + t1.GetDouble() * h3 + t2.GetDouble() * h4;
+
+    default:
+        return v1;
+    }
+}
+
+Variant SubstractAndMultiply(VariantType type, const Variant& v1, const Variant& v2, float t)
+{
+    switch (type)
+    {
+    case VAR_FLOAT:
+        return (v1.GetFloat() - v2.GetFloat()) * t;
+
+    case VAR_VECTOR2:
+        return (v1.GetVector2() - v2.GetVector2()) * t;
+
+    case VAR_VECTOR3:
+        return (v1.GetVector3() - v2.GetVector3()) * t;
+
+    case VAR_VECTOR4:
+        return (v1.GetVector4() - v2.GetVector4()) * t;
+
+    case VAR_QUATERNION:
+        return (v1.GetQuaternion() - v2.GetQuaternion()) * t;
+
+    case VAR_COLOR:
+        return (v1.GetColor() - v2.GetColor()) * t;
+
+    case VAR_DOUBLE:
+        return (v1.GetDouble() - v2.GetDouble()) * t;
+
+    default:
+        return Variant(type);
+    }
+}
+
+}
+
+void AnimationTrack::Sample(float time, float duration, bool isLooped, unsigned& frameIndex, Transform& value) const
+{
+    float blendFactor{};
+    unsigned nextFrameIndex{};
+    GetKeyFrames(time, duration, isLooped, frameIndex, nextFrameIndex, blendFactor);
+
+    const AnimationKeyFrame& keyFrame = keyFrames_[frameIndex];
+    const AnimationKeyFrame& nextKeyFrame = keyFrames_[nextFrameIndex];
+
+    if (blendFactor >= M_EPSILON)
+    {
+        if (channelMask_ & CHANNEL_POSITION)
+            value.position_ = keyFrame.position_.Lerp(nextKeyFrame.position_, blendFactor);
+        if (channelMask_ & CHANNEL_ROTATION)
+            value.rotation_ = keyFrame.rotation_.Slerp(nextKeyFrame.rotation_, blendFactor);
+        if (channelMask_ & CHANNEL_SCALE)
+            value.scale_ = keyFrame.scale_.Lerp(nextKeyFrame.scale_, blendFactor);
+    }
+    else
+    {
+        if (channelMask_ & CHANNEL_POSITION)
+            value.position_ = keyFrame.position_;
+        if (channelMask_ & CHANNEL_ROTATION)
+            value.rotation_ = keyFrame.rotation_;
+        if (channelMask_ & CHANNEL_SCALE)
+            value.scale_ = keyFrame.scale_;
+    }
+}
+
+void VariantAnimationTrack::Commit()
+{
+    type_ = GetType();
+
+    switch (type_)
+    {
+    case VAR_FLOAT:
+    case VAR_VECTOR2:
+    case VAR_VECTOR3:
+    case VAR_VECTOR4:
+    case VAR_QUATERNION:
+    case VAR_COLOR:
+    case VAR_DOUBLE:
+        // Floating point compounds may have any interpolation type.
+        // Calculate tangents if spline interpolation is used.
+        if (interpolation_ == KeyFrameInterpolation::Spline)
+        {
+            const unsigned numKeyFrames = keyFrames_.size();
+            splineTangents_.resize(numKeyFrames);
+
+            for (unsigned i = 1; i + 1 < numKeyFrames; ++i)
+            {
+                splineTangents_[i] = SubstractAndMultiply(
+                    type_, keyFrames_[i + 1].value_, keyFrames_[i - 1].value_, splineTension_);
+            }
+
+            // If spline is not closed, make end point's tangent zero
+            if (numKeyFrames <= 2 || keyFrames_[0].value_ != keyFrames_[numKeyFrames - 1].value_)
+            {
+                splineTangents_[0] = Variant(type_);
+                if (numKeyFrames >= 2)
+                    splineTangents_[numKeyFrames - 1] = Variant(type_);
+            }
+            else
+            {
+                const Variant tangent = SubstractAndMultiply(
+                    type_, keyFrames_[1].value_, keyFrames_[numKeyFrames - 2].value_, splineTension_);
+                splineTangents_[0] = tangent;
+                splineTangents_[numKeyFrames - 1] = tangent;
+            }
+        }
+        break;
+
+    case VAR_INT:
+    case VAR_INT64:
+    case VAR_INTRECT:
+    case VAR_INTVECTOR2:
+    case VAR_INTVECTOR3:
+        // Integer compounds cannot have spline interpolation, fallback to linear.
+        if (interpolation_ == KeyFrameInterpolation::Spline)
+            interpolation_ = KeyFrameInterpolation::Linear;
+        break;
+
+    default:
+        // Other types don't support interpolation at all, fallback to none.
+        interpolation_ = KeyFrameInterpolation::None;
+        break;
+    }
+}
+
+Variant VariantAnimationTrack::Sample(float time, float duration, bool isLooped, unsigned& frameIndex) const
+{
+    float blendFactor{};
+    unsigned nextFrameIndex{};
+    GetKeyFrames(time, duration, isLooped, frameIndex, nextFrameIndex, blendFactor);
+
+    const VariantAnimationKeyFrame& keyFrame = keyFrames_[frameIndex];
+    const VariantAnimationKeyFrame& nextKeyFrame = keyFrames_[nextFrameIndex];
+
+    if (blendFactor >= M_EPSILON)
+    {
+        if (interpolation_ == KeyFrameInterpolation::Spline && splineTangents_.size() == keyFrames_.size())
+        {
+            return InterpolateSpline(type_, keyFrame.value_, nextKeyFrame.value_,
+                splineTangents_[frameIndex], splineTangents_[nextFrameIndex], blendFactor);
+        }
+        else if (interpolation_ == KeyFrameInterpolation::Linear)
+            return keyFrame.value_.Lerp(nextKeyFrame.value_, blendFactor);
+    }
+
+    return keyFrame.value_;
+}
+
+VariantType VariantAnimationTrack::GetType() const
+{
+    return keyFrames_.empty() ? VAR_NONE : keyFrames_[0].value_.GetType();
+}
+
+}

--- a/Source/Urho3D/Graphics/AnimationTrack.h
+++ b/Source/Urho3D/Graphics/AnimationTrack.h
@@ -1,0 +1,122 @@
+//
+// Copyright (c) 2008-2020 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+/// \file
+
+#pragma once
+
+#include "../Container/FlagSet.h"
+#include "../Container/KeyFrameSet.h"
+#include "../Math/Transform.h"
+
+namespace Urho3D
+{
+
+enum AnimationChannel : unsigned char
+{
+    CHANNEL_NONE = 0x0,
+    CHANNEL_POSITION = 0x1,
+    CHANNEL_ROTATION = 0x2,
+    CHANNEL_SCALE = 0x4,
+};
+URHO3D_FLAGSET(AnimationChannel, AnimationChannelFlags);
+
+/// Method of interpolation between keyframes.
+enum class KeyFrameInterpolation
+{
+    None,
+    Linear,
+    Spline,
+};
+
+/// Skeletal animation keyframe.
+/// TODO: Replace inheritance with composition?
+struct AnimationKeyFrame : public Transform
+{
+    /// Keyframe time.
+    float time_{};
+
+    AnimationKeyFrame() = default;
+    AnimationKeyFrame(float time, const Vector3& position,
+        const Quaternion& rotation = Quaternion::IDENTITY, const Vector3& scale = Vector3::ONE)
+        : Transform{ position, rotation, scale }
+        , time_(time)
+    {
+    }
+};
+
+/// Skeletal animation track, stores keyframes of a single bone.
+/// @fakeref
+struct URHO3D_API AnimationTrack : public KeyFrameSet<AnimationKeyFrame>
+{
+    /// Bone or scene node name.
+    ea::string name_;
+    /// Name hash.
+    StringHash nameHash_;
+    /// Bitmask of included data (position, rotation, scale).
+    AnimationChannelFlags channelMask_{};
+    /// Base transform for additive animations.
+    /// If animation is applied to bones, bone initial transform is used instead.
+    Transform baseValue_;
+
+    /// Sample value at given time.
+    void Sample(float time, float duration, bool isLooped, unsigned& frameIndex, Transform& transform) const;
+};
+
+/// Generic variant animation keyframe.
+struct VariantAnimationKeyFrame
+{
+    /// Keyframe time.
+    float time_{};
+    /// Attribute value.
+    Variant value_;
+};
+
+/// Generic animation track, stores keyframes of single animatable entity.
+struct URHO3D_API VariantAnimationTrack : public KeyFrameSet<VariantAnimationKeyFrame>
+{
+    /// Annotated name of animatable entity.
+    ea::string name_;
+    /// Name hash.
+    StringHash nameHash_;
+    /// Base transform for additive animations.
+    Variant baseValue_;
+    /// Interpolation mode.
+    KeyFrameInterpolation interpolation_{ KeyFrameInterpolation::Linear };
+    /// Spline tension for spline interpolation.
+    float splineTension_{ 0.5f };
+
+    /// Cached data (never serialized, recalculated on commit).
+    /// @{
+    VariantType type_{};
+    ea::vector<Variant> splineTangents_;
+    /// @}
+
+    /// Commit changes and recalculate derived members. May change interpolation mode.
+    void Commit();
+    /// Sample value at given time.
+    Variant Sample(float time, float duration, bool isLooped, unsigned& frameIndex) const;
+    /// Return type of animation track. Defined by the type of the first keyframe.
+    VariantType GetType() const;
+};
+
+}

--- a/Source/Urho3D/Graphics/ModelView.cpp
+++ b/Source/Urho3D/Graphics/ModelView.cpp
@@ -654,9 +654,10 @@ void ModelView::ExportModel(Model* model) const
     model->SetSkeleton(skeleton);
 }
 
-SharedPtr<Model> ModelView::ExportModel() const
+SharedPtr<Model> ModelView::ExportModel(const ea::string& name) const
 {
     auto model = MakeShared<Model>(context_);
+    model->SetName(name);
     ExportModel(model);
     return model;
 }

--- a/Source/Urho3D/Graphics/ModelView.h
+++ b/Source/Urho3D/Graphics/ModelView.h
@@ -194,7 +194,7 @@ public:
     /// @{
     bool ImportModel(const Model* model);
     void ExportModel(Model* model) const;
-    SharedPtr<Model> ExportModel() const;
+    SharedPtr<Model> ExportModel(const ea::string& name = EMPTY_STRING) const;
     /// @}
 
     /// Calculate bounding box.

--- a/Source/Urho3D/Math/MathDefs.h
+++ b/Source/Urho3D/Math/MathDefs.h
@@ -74,7 +74,7 @@ inline bool Equals(T lhs, T rhs, T eps = M_EPSILON) { return lhs + eps >= rhs &&
 /// Linear interpolation between two values.
 /// @specialization{float,float}
 template <class T, class U>
-inline T Lerp(T lhs, T rhs, U t) { return lhs * (1.0 - t) + rhs * t; }
+inline T Lerp(T lhs, T rhs, U t) { return static_cast<T>(lhs * (1.0 - t) + rhs * t); }
 
 /// Inverse linear interpolation between two values.
 /// @specialization{float}

--- a/Source/Urho3D/Math/Transform.h
+++ b/Source/Urho3D/Math/Transform.h
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2021 the rbfx project.
+// Copyright (c) 2017-2020 the rbfx project.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,30 +22,19 @@
 
 #pragma once
 
-#include "SceneUtils.h"
+#include "../Math/Vector3.h"
+#include "../Math/Quaternion.h"
 
-#include <Urho3D/Resource/XMLFile.h>
-
-namespace Tests
+namespace Urho3D
 {
 
-void SerializeAndDeserializeScene(Scene* scene)
+/// Position, rotation and scale in 3D.
+/// TODO: Expand it into something more user-friendly.
+struct Transform
 {
-    auto xmlFile = MakeShared<XMLFile>(scene->GetContext());
-    auto xmlRoot = xmlFile->GetOrCreateRoot("scene");
-    scene->SaveXML(xmlRoot);
-    scene->Clear();
-    scene->LoadXML(xmlRoot);
-}
-
-Variant GetAttributeValue(const ea::pair<Serializable*, unsigned>& ref)
-{
-    return ref.first->GetAttribute(ref.second);
-}
-
-Node* NodeRef::GetNode() const
-{
-    return scene_ ? scene_->GetChild(name_, true) : nullptr;
-}
+    Vector3 position_;
+    Quaternion rotation_;
+    Vector3 scale_{ Vector3::ONE };
+};
 
 }

--- a/Source/Urho3D/Resource/Resource.cpp
+++ b/Source/Urho3D/Resource/Resource.cpp
@@ -156,12 +156,14 @@ bool ResourceWithMetadata::HasMetadata() const
 
 void ResourceWithMetadata::LoadMetadataFromXML(const XMLElement& source)
 {
+    RemoveAllMetadata();
     for (XMLElement elem = source.GetChild("metadata"); elem; elem = elem.GetNext("metadata"))
         AddMetadata(elem.GetAttribute("name"), elem.GetVariant());
 }
 
 void ResourceWithMetadata::LoadMetadataFromJSON(const JSONArray& array)
 {
+    RemoveAllMetadata();
     for (unsigned i = 0; i < array.size(); i++)
     {
         const JSONValue& value = array.at(i);

--- a/Source/Urho3D/Scene/Node.cpp
+++ b/Source/Urho3D/Scene/Node.cpp
@@ -38,6 +38,8 @@
 #include "../Scene/SmoothedTransform.h"
 #include "../Scene/UnknownComponent.h"
 
+#include <charconv>
+
 #include "../DebugNew.h"
 
 #ifdef _MSC_VER
@@ -1482,6 +1484,74 @@ Node* Node::GetChild(StringHash nameHash, bool recursive) const
     }
 
     return nullptr;
+}
+
+Node* Node::GetChildByNameOrIndex(ea::string_view name) const
+{
+    if (name.empty())
+        return nullptr;
+
+    if (name[0] == '#')
+    {
+        unsigned index = 0;
+        const auto result = std::from_chars(name.begin() + 1, name.end(), index, 10);
+        if (result.ec == std::errc{} && result.ptr == name.end())
+            return GetChild(index);
+    }
+
+    return GetChild(StringHash(name));
+}
+
+Serializable* Node::GetSerializableByName(ea::string_view name) const
+{
+    if (name.empty())
+        return const_cast<Node*>(this);
+
+    // TODO(animation): Support multiple components of the same type
+    return GetComponent(StringHash(name));
+}
+
+Node* Node::FindChild(ea::string_view path) const
+{
+    const auto sep = path.find_first_of('/');
+    const bool isLast = sep == ea::string_view::npos;
+    const ea::string_view childName = isLast ? path : path.substr(0, sep);
+    if (childName.empty())
+        return nullptr;
+
+    Node* child = GetChildByNameOrIndex(childName);
+    return child && !isLast ? child->FindChild(path.substr(sep + 1)) : child;
+}
+
+ea::pair<Serializable*, unsigned> Node::FindComponentAttribute(ea::string_view path) const
+{
+    const auto sep = path.find_first_of('/');
+    if (path.empty() || path[0] != '@' || sep == ea::string_view::npos)
+        return {};
+
+    const ea::string_view componentName = path.substr(1, sep - 1);
+    const ea::string_view attributeName = path.substr(sep + 1);
+
+    Serializable* serializable = GetSerializableByName(componentName);
+    if (!serializable)
+        return {};
+
+    const auto* attributes = serializable->GetAttributes();
+    if (!attributes)
+        return {};
+
+    const auto iter = ea::find_if(attributes->begin(), attributes->end(),
+        [&](const AttributeInfo& info)
+    {
+        return ea::string::comparei(
+            info.name_.begin(), info.name_.end(), attributeName.begin(), attributeName.end()) == 0;
+    });
+
+    if (iter == attributes->end())
+        return {};
+
+    const unsigned attributeIndex = iter - attributes->begin();
+    return { serializable, attributeIndex };
 }
 
 unsigned Node::GetNumNetworkComponents() const

--- a/Source/Urho3D/Scene/Node.h
+++ b/Source/Urho3D/Scene/Node.h
@@ -592,6 +592,12 @@ public:
     Node* GetChild(const char* name, bool recursive = false) const;
     /// Return child scene node by name hash.
     Node* GetChild(StringHash nameHash, bool recursive = false) const;
+    /// Find child node by path string in format "Parent Name/Child Name/Grandchild Name/..."
+    /// Node index may be used instead of name: ".../#10/..."
+    Node* FindChild(ea::string_view path) const;
+    /// Find attribute of itself or owned component by path string in format "@ComponentName/Attribute Name".
+    /// If component name is not specified, attribute is searched in the node itself: "@/Position".
+    ea::pair<Serializable*, unsigned> FindComponentAttribute(ea::string_view path) const;
 
     /// Return number of components.
     /// @property
@@ -732,6 +738,11 @@ private:
     void RemoveComponent(ea::vector<SharedPtr<Component> >::iterator i);
     /// Handle attribute animation update event.
     void HandleAttributeAnimationUpdate(StringHash eventType, VariantMap& eventData);
+    /// Find child node by index if name is an integer starting with "#" (like "#12" or "#0").
+    /// Find child by name otherwise. Empty name is considered invalid.
+    Node* GetChildByNameOrIndex(ea::string_view name) const;
+    /// Find component by name. If name is empty, returns the owner node itself.
+    Serializable* GetSerializableByName(ea::string_view name) const;
 
     /// World-space transform matrix.
     mutable Matrix3x4 worldTransform_;

--- a/bin/Data/Animations/LightAnimation.xml
+++ b/bin/Data/Animations/LightAnimation.xml
@@ -1,0 +1,16 @@
+<animation length="4.0">
+    <variant name="@/Position" type="Vector3" interpolation="spline" tension="0.7">
+        <keyframe time="0.0" value="-30.0 5.0 -30.0"/>
+        <keyframe time="1.0" value=" 30.0 5.0 -30.0"/>
+        <keyframe time="2.0" value=" 30.0 5.0  30.0"/>
+        <keyframe time="3.0" value="-30.0 5.0  30.0"/>
+        <keyframe time="4.0" value="-30.0 5.0 -30.0"/>
+    </variant>
+    <variant name="@Light/Color" type="Color">
+        <keyframe time="0.0" value="1 1 1 1"/>
+        <keyframe time="1.0" value="1 0 0 1"/>
+        <keyframe time="2.0" value="1 1 0 1"/>
+        <keyframe time="3.0" value="0 1 0 1"/>
+        <keyframe time="4.0" value="1 1 1 1"/>
+    </variant>
+</animation>


### PR DESCRIPTION
Changes:

- `AnimatedModel` cannot be animated on its own anymore, `AnimationController` or some other component is required to supply animation states;
- `AnimationController` can animate arbitrary attribute of arbitrary child node or component, not just bone transforms;
- Object and value animations (applied via Animatable) are considered deprecated (but not removed yet);
- Animation can be loaded from XML file for sake of simpler prototyping;
- Minor fixes and feature parity updates.