### PR TITLE
Let user detect if path wast cut and do not lead to the requested location

### DIFF
--- a/Source/Samples/15_Navigation/Navigation.cpp
+++ b/Source/Samples/15_Navigation/Navigation.cpp
@@ -290,7 +290,8 @@ void Navigation::SetPathPoint()
         {
             // Calculate path from Jack's current position to the end point
             endPos_ = pathPos;
-            navMesh->FindPath(currentPath_, jackNode_->GetPosition(), endPos_);
+            bool pathWasCut = false;
+            navMesh->FindPath(currentPath_, pathWasCut, jackNode_->GetPosition(), endPos_);
         }
     }
 }
@@ -322,8 +323,10 @@ void Navigation::AddOrRemoveObject()
         // Rebuild part of the navigation mesh, then recalculate path if applicable
         auto* navMesh = scene_->GetComponent<NavigationMesh>();
         navMesh->Build(updateBox);
-        if (currentPath_.size())
-            navMesh->FindPath(currentPath_, jackNode_->GetPosition(), endPos_);
+        if (currentPath_.size()) {
+            bool pathWasCut = false;
+            navMesh->FindPath(currentPath_, pathWasCut, jackNode_->GetPosition(), endPos_);
+        }
     }
 }
 

--- a/Source/Urho3D/Navigation/CrowdManager.cpp
+++ b/Source/Urho3D/Navigation/CrowdManager.cpp
@@ -399,8 +399,9 @@ Vector3 CrowdManager::MoveAlongSurface(const Vector3& start, const Vector3& end,
 
 void CrowdManager::FindPath(ea::vector<Vector3>& dest, const Vector3& start, const Vector3& end, int queryFilterType)
 {
+    bool pathWasCut = false;
     if (crowd_ && navigationMesh_)
-        navigationMesh_->FindPath(dest, start, end, Vector3(crowd_->getQueryExtents()), crowd_->getFilter(queryFilterType));
+        navigationMesh_->FindPath(dest, pathWasCut, start, end, Vector3(crowd_->getQueryExtents()), crowd_->getFilter(queryFilterType));
 }
 
 Vector3 CrowdManager::GetRandomPoint(int queryFilterType, dtPolyRef* randomRef)

--- a/Source/Urho3D/Navigation/NavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/NavigationMesh.cpp
@@ -622,22 +622,23 @@ Vector3 NavigationMesh::MoveAlongSurface(const Vector3& start, const Vector3& en
     return transform * resultPos;
 }
 
-void NavigationMesh::FindPath(ea::vector<Vector3>& dest, const Vector3& start, const Vector3& end, const Vector3& extents,
+void NavigationMesh::FindPath(ea::vector<Vector3>& dest, bool &pathWasCut, const Vector3& start, const Vector3& end, const Vector3& extents,
     const dtQueryFilter* filter)
 {
     ea::vector<NavigationPathPoint> navPathPoints;
-    FindPath(navPathPoints, start, end, extents, filter);
+    FindPath(navPathPoints, pathWasCut, start, end, extents, filter);
 
     dest.clear();
     for (unsigned i = 0; i < navPathPoints.size(); ++i)
         dest.push_back(navPathPoints[i].position_);
 }
 
-void NavigationMesh::FindPath(ea::vector<NavigationPathPoint>& dest, const Vector3& start, const Vector3& end,
+void NavigationMesh::FindPath(ea::vector<NavigationPathPoint>& dest, bool &pathWasCut, const Vector3& start, const Vector3& end,
     const Vector3& extents, const dtQueryFilter* filter)
 {
     URHO3D_PROFILE("FindPath");
     dest.clear();
+    pathWasCut = false;
 
     if (!InitializeQuery())
         return;
@@ -669,8 +670,10 @@ void NavigationMesh::FindPath(ea::vector<NavigationPathPoint>& dest, const Vecto
     Vector3 actualLocalEnd = localEnd;
 
     // If full path was not found, clamp end point to the end polygon
-    if (pathData_->polys_[numPolys - 1] != endRef)
+    if (pathData_->polys_[numPolys - 1] != endRef) {
+        pathWasCut = true;
         navMeshQuery_->closestPointOnPoly(pathData_->polys_[numPolys - 1], &localEnd.x_, &actualLocalEnd.x_, nullptr);
+    }
 
     navMeshQuery_->findStraightPath(&localStart.x_, &actualLocalEnd.x_, pathData_->polys_, numPolys,
         &pathData_->pathPoints_[0].x_, pathData_->pathFlags_, pathData_->pathPolys_, &numPathPoints, MAX_POLYS);

--- a/Source/Urho3D/Navigation/NavigationMesh.h
+++ b/Source/Urho3D/Navigation/NavigationMesh.h
@@ -180,11 +180,11 @@ public:
     Vector3 MoveAlongSurface(const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE, int maxVisited = 3,
         const dtQueryFilter* filter = nullptr);
     /// Find a path between world space points. Return non-empty list of points if successful. Extents specifies how far off the navigation mesh the points can be.
-    void FindPath(ea::vector<Vector3>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE,
+    void FindPath(ea::vector<Vector3>& dest, bool &pathWasCut, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE,
         const dtQueryFilter* filter = nullptr);
     /// Find a path between world space points. Return non-empty list of navigation path points if successful. Extents specifies how far off the navigation mesh the points can be.
     void FindPath
-        (ea::vector<NavigationPathPoint>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE,
+        (ea::vector<NavigationPathPoint>& dest, bool &pathWasCut, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE,
             const dtQueryFilter* filter = nullptr);
     /// Return a random point on the navigation mesh.
     Vector3 GetRandomPoint(const dtQueryFilter* filter = nullptr, dtPolyRef* randomRef = nullptr);


### PR DESCRIPTION
Right now nav mesh successfully build path to every distant location. The problem starts when you try to build a path to the isolated region - it can be blocked by closed door for example.

There is a code from rbfx to cut the path in such situation and there is no indication if that was the case.

Now, output variable `pathWasCut` will indicate the fact that path was actually cut and did not reach the final location.