### PR TITLE
Graphics: Ignore borderless parameter unless windows are full-screen.

### DIFF
--- a/Source/Urho3D/Graphics/Graphics.cpp
+++ b/Source/Urho3D/Graphics/Graphics.cpp
@@ -531,6 +531,10 @@ void Graphics::AdjustScreenMode(int& newWidth, int& newHeight, ScreenModeParams&
     if (params.monitor_ >= numMonitors || params.monitor_ < 0)
         params.monitor_ = 0; // this monitor is not present, use first monitor
 
+    // Borderless windows make no sense unless they are full-screen.
+    if (!params.fullscreen_)
+        params.borderless_ = false;
+
     // Fullscreen or Borderless can not be resizable and cannot be maximized
     if (params.fullscreen_ || params.borderless_)
     {


### PR DESCRIPTION
I do agree that borderless fullscreen as a default is OK, but it does not make much sense for windowed apps. How about we do something like this?