### PR TITLE
Editor --plugin command line argument

### DIFF
--- a/Source/Editor/Editor.cpp
+++ b/Source/Editor/Editor.cpp
@@ -192,6 +192,7 @@ void Editor::Setup()
     auto& cmd = GetCommandLineParser();
     cmd.add_flag("--read-only", readOnly_, "Prevents Editor from modifying any project files, unless it is explicitly done via executed command.");
     cmd.add_option("--command", command_, "Command to execute on startup.")->type_name("command");
+    cmd.add_option("--plugin", implicitPlugin_, "Path to plugin file.");
     cmd.add_flag("--exit", exitAfterCommand_, "Forces Editor to exit after command execution.");
     cmd.add_option("project", pendingOpenProject_, "Project to open or create on startup.")->type_name("dir");
 
@@ -586,7 +587,7 @@ void Editor::RenderAboutDialog()
 
     ui::BeginDisabled();
     ui::Text("Copyright © 2008-2022 the Urho3D project.");
-    ui::Text("Copyright © 2017-2022 the rbfx project.");
+    ui::Text("Copyright © 2017-2023 the rbfx project.");
     ui::EndDisabled();
 
     ui::End();
@@ -632,7 +633,7 @@ void Editor::UpdateProjectStatus()
         if (!isHeadless)
             InitializeUI();
 
-        project_ = MakeShared<Project>(context_, pendingOpenProject_, settingsJsonPath_, readOnly_);
+        project_ = MakeShared<Project>(context_, pendingOpenProject_, settingsJsonPath_, implicitPlugin_, readOnly_);
         project_->OnShallowSaved.Subscribe(this, &Editor::SaveTempJson);
 
         recentProjects_.erase_first(pendingOpenProject_);

--- a/Source/Editor/Editor.h
+++ b/Source/Editor/Editor.h
@@ -93,6 +93,8 @@ protected:
     bool readOnly_{};
     /// Launch command and command line parameters.
     ea::string command_;
+    /// Implicit plugin dynamic library name.
+    ea::string implicitPlugin_;
     /// Whether to exit the editor after executing the command.
     bool exitAfterCommand_{};
 

--- a/Source/Editor/ManagedHost/Editor.csproj
+++ b/Source/Editor/ManagedHost/Editor.csproj
@@ -1,8 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Editor</AssemblyName>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <LangVersion>9.0</LangVersion>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>rbfx</ToolCommandName>
+    <PackageID>rbfx.Urho3DNet.Editor</PackageID>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <TargetFramework>$(URHO3D_NETFX_RUNTIME)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/Editor/Project/Project.cpp
+++ b/Source/Editor/Project/Project.cpp
@@ -194,7 +194,7 @@ ImFont* Project::GetMonoFont()
     return monoFont;
 }
 
-Project::Project(Context* context, const ea::string& projectPath, const ea::string& settingsJsonPath, bool isReadOnly)
+Project::Project(Context* context, const ea::string& projectPath, const ea::string& settingsJsonPath, const ea::string&implicitPlugin, bool isReadOnly)
     : Object(context)
     , isHeadless_(context->GetSubsystem<Engine>()->IsHeadless())
     , isReadOnly_(isReadOnly)
@@ -251,6 +251,8 @@ Project::Project(Context* context, const ea::string& projectPath, const ea::stri
 
     settingsManager_->LoadFile(settingsJsonPath_);
     assetManager_->LoadFile(cacheJsonPath_);
+
+    pluginManager_->SetImplicitPlugin(implicitPlugin);
 
     JSONFile projectJsonFile(context_);
     projectJsonFile.LoadFile(projectJsonPath_);

--- a/Source/Editor/Project/Project.h
+++ b/Source/Editor/Project/Project.h
@@ -111,7 +111,8 @@ public:
     Signal<void(ProjectRequest*)> OnRequest;
     Signal<void(const ea::string& command, const ea::string& args, bool& processed)> OnCommand;
 
-    Project(Context* context, const ea::string& projectPath, const ea::string& settingsJsonPath, bool isReadOnly);
+    Project(Context* context, const ea::string& projectPath, const ea::string& settingsJsonPath,
+        const ea::string& implicitPlugin, bool isReadOnly);
     ~Project() override;
     void SerializeInBlock(Archive& archive) override;
 

--- a/Source/Urho3D/CSharp/Native/Context.cpp
+++ b/Source/Urho3D/CSharp/Native/Context.cpp
@@ -54,6 +54,10 @@ URHO3D_EXPORT_API void SWIGSTDCALL Urho3D_Context_RegisterFactory(Context* conte
     auto typeInfo = ea::make_unique<TypeInfo>(typeName, Urho3DGetDirectorTypeInfo(StringHash(baseType)));
     auto reflection = context->ReflectCustomType(ea::move(typeInfo));
     reflection->SetObjectFactory(CreateManagedObject);
+    if (category)
+    {
+        context->SetReflectionCategory(reflection->GetTypeInfo(), category);
+    }
 }
 
 URHO3D_EXPORT_API void SWIGSTDCALL Urho3D_ParseArguments(int argc, char** argv)

--- a/Source/Urho3D/Plugins/DynamicModule.cpp
+++ b/Source/Urho3D/Plugins/DynamicModule.cpp
@@ -363,7 +363,7 @@ ModuleType DynamicModule::ReadModuleInformation(Context* context, const ea::stri
             return MODULE_INVALID;
 
         auto* nt = reinterpret_cast<PIMAGE_NT_HEADERS>(data.data() + dos->e_lfanew);
-        if (!IsValidPtr(data, dos) || nt->OptionalHeader.Magic != IMAGE_NT_OPTIONAL_HDR_MAGIC)
+        if (!IsValidPtr(data, dos))// || nt->OptionalHeader.Magic != IMAGE_NT_OPTIONAL_HDR64_MAGIC)
             return MODULE_INVALID;
 
         const auto& eatDir = nt->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT];

--- a/Source/Urho3D/Plugins/ModulePlugin.cpp
+++ b/Source/Urho3D/Plugins/ModulePlugin.cpp
@@ -103,6 +103,14 @@ ea::string ModulePlugin::NameToPath(const ea::string& name) const
     FileSystem* fs = context_->GetSubsystem<FileSystem>();
     ea::string result;
 
+    if (IsAbsolutePath(name))
+    {
+        if (fs->FileExists(name))
+            return name;
+
+        return EMPTY_STRING;
+    }
+
 #if __linux__ || __APPLE__
     result = Format("{}lib{}{}", fs->GetProgramDir(), name, DYN_LIB_SUFFIX);
     if (fs->FileExists(result))

--- a/Source/Urho3D/Plugins/PluginManager.cpp
+++ b/Source/Urho3D/Plugins/PluginManager.cpp
@@ -316,6 +316,16 @@ void PluginManager::SetPluginsLoaded(const StringVector& plugins)
     revision_ = ea::max(1u, revision_ + 1);
 }
 
+void PluginManager::SetImplicitPlugin(const ea::string& implicitPlugin)
+{
+    if (implicitPlugin_ != implicitPlugin)
+    {
+        implicitPlugin_ = implicitPlugin;
+        stackReloadPending_ = true;
+        revision_ = ea::max(1u, revision_ + 1);
+    }
+}
+
 bool PluginManager::IsPluginLoaded(const ea::string& name)
 {
     PluginApplication* application = GetPluginApplication(name, true);
@@ -435,8 +445,14 @@ void PluginManager::DisposeStack()
 void PluginManager::RestoreStack()
 {
     URHO3D_ASSERT(pluginStack_ == nullptr);
-
-    pluginStack_ = MakeShared<PluginStack>(this, loadedPlugins_);
+    StringVector loadedPlugins;
+    loadedPlugins.reserve(loadedPlugins_.size() + 1);
+    if (!implicitPlugin_.empty())
+    {
+        loadedPlugins.push_back(implicitPlugin_);
+    }
+    loadedPlugins.insert(loadedPlugins.end(), loadedPlugins_.begin(), loadedPlugins_.end());
+    pluginStack_ = MakeShared<PluginStack>(this, loadedPlugins);
     if (wasStarted_)
         pluginStack_->ResumeApplication(restoreBuffer_);
     restoreBuffer_.clear();

--- a/Source/Urho3D/Plugins/PluginManager.h
+++ b/Source/Urho3D/Plugins/PluginManager.h
@@ -107,6 +107,10 @@ public:
 
     /// Set loaded plugins. Order is preserved.
     void SetPluginsLoaded(const StringVector& plugins);
+    /// Set implicit plugin name.
+    void SetImplicitPlugin(const ea::string& implicitPlugin);
+    /// Get implicit plugin name.
+    const ea::string& GetImplicitPlugin() const { return implicitPlugin_; };
     /// Return whether the plugin is loaded.
     bool IsPluginLoaded(const ea::string& name);
     /// Return loaded plugins.
@@ -165,6 +169,7 @@ private:
     bool stopPending_{};
     bool stackReloadPending_{};
     StringVector loadedPlugins_;
+    ea::string implicitPlugin_;
     unsigned revision_{};
     SharedPtr<PluginStack> pluginStack_;
 


### PR DESCRIPTION
Editor now accepts --plugin command as an argument.

The plugin name treated as an "implicit plugin", i.e it is injected into project even if it is not mentioned in the project configuration.

nt->OptionalHeader.Magic is ignored because netstandard2.0 assembly seems to be marked as 32-bit even if built for x64 platform and it works just fine.