### PR TITLE
Cmake library name error fix for openxr_loader

### DIFF
--- a/Source/ThirdParty/OpenXRSDK/src/CMakeLists.txt
+++ b/Source/ThirdParty/OpenXRSDK/src/CMakeLists.txt
@@ -102,7 +102,7 @@ option(
 )
 
 if(WIN32)
-    set(OPENXR_DEBUG_POSTFIX d CACHE STRING "OpenXR loader debug postfix.")
+    set(OPENXR_DEBUG_POSTFIX "" CACHE STRING "OpenXR loader debug postfix.")
 else()
     set(OPENXR_DEBUG_POSTFIX "" CACHE STRING "OpenXR loader debug postfix.")
 endif()

--- a/Source/ThirdParty/OpenXRSDK/src/loader/CMakeLists.txt
+++ b/Source/ThirdParty/OpenXRSDK/src/loader/CMakeLists.txt
@@ -203,8 +203,8 @@ elseif(WIN32)
 
     # Need to copy DLL to client directories so clients can easily load it.
     if(DYNAMIC_LOADER AND (CMAKE_GENERATOR MATCHES "^Visual Studio.*"))
-        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/openxr_loader$<$<CONFIG:Debug>:${OPENXR_DEBUG_POSTFIX}>.dll COPY_DLL_SRC_PATH)
-        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/openxr_loader$<$<CONFIG:Debug>:${OPENXR_DEBUG_POSTFIX}>.pdb COPY_PDB_SRC_PATH)
+        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/openxr_loader.dll COPY_DLL_SRC_PATH)
+        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/openxr_loader.pdb COPY_PDB_SRC_PATH)
         file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../tests/hello_xr/$<CONFIGURATION>/
              COPY_DST_HELLO_XR_PATH
         )


### PR DESCRIPTION
For debug, it was outputting as openxr_loaderd.lib, I fixed it. The folder names were separated as debug and release, there was no need to separate them in the file name.