### PR TITLE
Fix for PACKAGE_TOOL cmake cli arg being overriden when not using URHO3D_SDK and URHO3D_TOOLS

### DIFF
--- a/CMake/Modules/UrhoCommon.cmake
+++ b/CMake/Modules/UrhoCommon.cmake
@@ -66,7 +66,7 @@ if (DEFINED URHO3D_SDK)
     endif ()
 endif ()
 
-if (NOT DEFINED URHO3D_SDK)
+if (NOT DEFINED URHO3D_SDK AND URHO3D_TOOLS)
     set (PACKAGE_TOOL $<TARGET_FILE:PackageTool>)
     set (SWIG_EXECUTABLE $<TARGET_FILE:swig>)
 endif ()


### PR DESCRIPTION
I got this error when I tried to build the sample-project for web when using a source build of the engine and passing in a pre-built path for -DPACKAGE_TOOL

> PackageTool is required, but missing. Either set URHO3D_SDK to path of installed SDK built on current host or set PACKAGE_TOOL to path of PackageTool executable.
