### PR TITLE
Fix erase_first return check in ListView

### DIFF
--- a/Source/Urho3D/UI/ListView.cpp
+++ b/Source/Urho3D/UI/ListView.cpp
@@ -633,7 +633,7 @@ void ListView::RemoveSelection(unsigned index)
     if (index >= GetNumItems())
         return;
 
-    if (selections_.erase_first(index))
+    if (selections_.erase_first(index) != selections_.end())
     {
         using namespace ItemSelected;
 


### PR DESCRIPTION
`vector::end()` pointing to the end of a vector buffer doesn't convert to boolean `false` when treated as a boolean. Especially since EASTL vector iterator is just a regular pointer.