### PR TITLE
Correct inversion of stereo and mono cases in non-interpolated SoundS…

### DIFF
--- a/Source/Urho3D/Audio/SoundSource.cpp
+++ b/Source/Urho3D/Audio/SoundSource.cpp
@@ -451,11 +451,11 @@ void SoundSource::Mix(int dest[], unsigned samples, int mixRate, SpeakerMode mod
                 break;
             case SPK_MONO:
                 if (!lowFrequency_)
-                    MixMonoToStereo(sound, dest, samples, mixRate, effectiveFrequency);
+                    MixMonoToMono(sound, dest, samples, mixRate, effectiveFrequency);
                 break;
             case SPK_STEREO:
                 if (!lowFrequency_)
-                    MixMonoToMono(sound, dest, samples, mixRate, effectiveFrequency);
+                    MixMonoToStereo(sound, dest, samples, mixRate, effectiveFrequency);
                 break;
             case SPK_QUADROPHONIC:
                 if (!lowFrequency_)


### PR DESCRIPTION
…ouce::Mix

I was trying out the sound effects sample and was wondering why the pan slider wasn't doing anything, so I asked deepwiki and it found this